### PR TITLE
Additional patching for ppc64le

### DIFF
--- a/third_party/0001-third_party-libvpx-Properly-generate-gni-on-ppc64.patch
+++ b/third_party/0001-third_party-libvpx-Properly-generate-gni-on-ppc64.patch
@@ -22,6 +22,18 @@ index c1b718e..db3b003 100644
  
    configs -= [ "//build/config/compiler:chromium_code" ]
    configs += [ "//build/config/compiler:no_chromium_code" ]
+   
+@@ -401,7 +412,10 @@ static_library("libvp9rc") {
+     } else {
+       sources = libvpx_srcs_arm64
+     }
++  } else if (current_cpu == "ppc64") {
++    sources = libvpx_srcs_ppc64
+   }
++
+   sources += [ "//third_party/libvpx/source/libvpx/vp9/ratectrl_rtc.cc" ]
+   sources += [ "//third_party/libvpx/source/libvpx/vp9/ratectrl_rtc.h" ]
+   
 diff --git a/third_party/libvpx/generate_gni.sh b/third_party/libvpx/generate_gni.sh
 index 2c94f6f685a3..c1758c6f193a 100755
 --- a/third_party/libvpx/generate_gni.sh


### PR DESCRIPTION
Hi @shawnanastasio ,

I was working on the build of Chromium 84.0.4119.0. And the build failed with the following error :


`
ERROR at //third_party/libvpx/BUILD.gn:417:3: Undefined identifier.
  sources += [ "//third_party/libvpx/source/libvpx/vp9/ratectrl_rtc.cc" ]
  ^------
See //media/cast/BUILD.gn:166:5: 
which caused the file to be included.
    "//third_party/libvpx",
    ^---------------------
`

I was able to get this resolved by using this patch and I thought you might want to include it as part of your patch file . 
Let me know if this doesn't apply to the version you currently working on .

Thanks,
Lysanne