### PR TITLE
Fix memory_allocator_unittest.cc in breakpad patch

### DIFF
--- a/breakpad/0001-Implement-ppc64-support-on-linux.patch
+++ b/breakpad/0001-Implement-ppc64-support-on-linux.patch
@@ -685,13 +685,13 @@ index 43c86314..27325b81 100644
 @@ -57,8 +57,9 @@ TEST(PageAllocatorTest, LargeObject) {
  
    EXPECT_EQ(0U, allocator.pages_allocated());
-   uint8_t *p = reinterpret_cast<uint8_t*>(allocator.Alloc(10000));
+   uint8_t* p = reinterpret_cast<uint8_t*>(allocator.Alloc(10000));
 +  uint64_t expected_pages = 1 + ((10000 - 1) / getpagesize());
    ASSERT_FALSE(p == NULL);
 -  EXPECT_EQ(3U, allocator.pages_allocated());
 +  EXPECT_EQ(expected_pages, allocator.pages_allocated());
    for (unsigned i = 1; i < 10; ++i) {
-     uint8_t *p = reinterpret_cast<uint8_t*>(allocator.Alloc(i));
+     uint8_t* p = reinterpret_cast<uint8_t*>(allocator.Alloc(i));
      ASSERT_FALSE(p == NULL);
 diff --git a/src/processor/exploitability_linux.cc b/src/processor/exploitability_linux.cc
 index ccc9f145..debaed4d 100644


### PR DESCRIPTION
Some large code style fixes were applied and it broke the patch.

See: https://chromium.googlesource.com/breakpad/breakpad/+/09b056975dacd1f0f815ad820b6dc9913b0118a3