### PR TITLE
Implement/Update patches for chromium version 95.0.4609.6

### DIFF
--- a/breakpad/0001-ppc64-have-context-support.patch
+++ b/breakpad/0001-ppc64-have-context-support.patch
@@ -1,0 +1,27 @@
+diff --git a/third_party/breakpad/BUILD.gn b/third_party/breakpad/BUILD.gn
+index a0c3bf474808..9e49f376d3a9 100644
+--- a/third_party/breakpad/BUILD.gn
++++ b/third_party/breakpad/BUILD.gn
+@@ -655,6 +655,11 @@ if (is_linux || is_chromeos || is_android) {
+     configs += [ "//build/config/compiler:no_chromium_code" ]
+     public_configs = [ ":client_config" ]
+
++    if (current_cpu == "ppc64") {
++      defines = [ "HAVE_GETCONTEXT" ]
++      sources -= ["breakpad/src/common/linux/breakpad_getcontext.S",]
++    }
++
+     if (current_cpu == "arm" && is_chromeos_ash) {
+       # Avoid running out of registers in
+       # linux_syscall_support.h:sys_clone()'s inline assembly.
+@@ -731,6 +736,10 @@ if (is_linux || is_chromeos || is_android) {
+       "linux/breakpad_googletest_includes.h",
+     ]
+
++    if (current_cpu == "ppc64") {
++      sources -= ["breakpad/src/common/linux/breakpad_getcontext_unittest.cc",]
++    }
++
+     deps = [
+       ":client",
+       ":processor_support",

--- a/crashpad/0001-Implement-support-for-PPC64-on-Linux.patch
+++ b/crashpad/0001-Implement-support-for-PPC64-on-Linux.patch
@@ -18,12 +18,11 @@ This patch implements support for the PPC64 architecture on Linux hosts.
  snapshot/cpu_context.cc                       |   5 +
  snapshot/cpu_context.h                        |  19 ++
  snapshot/linux/cpu_context_linux.h            |  73 ++++++
- snapshot/linux/debug_rendezvous_test.cc       |   4 +-
+ snapshot/linux/debug_rendezvous_test.cc       |   9 +-
  snapshot/linux/exception_snapshot_linux.cc    |  63 ++++++
  snapshot/linux/exception_snapshot_linux.h     |   2 +
  .../linux/exception_snapshot_linux_test.cc    |  21 ++
  snapshot/linux/process_reader_linux.cc        |   2 +
- snapshot/linux/process_reader_linux_test.cc   |   2 +
  snapshot/linux/signal_context.h               |  83 +++++++
  snapshot/linux/system_snapshot_linux.cc       |  11 +
  snapshot/linux/thread_snapshot_linux.cc       |   8 +
@@ -33,15 +32,15 @@ This patch implements support for the PPC64 architecture on Linux hosts.
  test/linux/get_tls.cc                         |   2 +
  test/multiprocess_posix.cc                    |   3 +-
  util/linux/auxiliary_vector.cc                |   5 +
- util/linux/ptrace_broker.cc                   |   4 +-
  util/linux/ptracer.cc                         |  61 +++++
  util/linux/thread_info.h                      |  55 +++++
  util/misc/capture_context.h                   |   1 +
  util/misc/capture_context_linux.S             | 212 +++++++++++++++++-
  util/misc/capture_context_test.cc             |   3 +-
  util/misc/capture_context_test_util_linux.cc  |   6 +
+ util/net/http_transport_libcurl.cc            |   2 ++
  util/posix/signals_test.cc                    |  12 +-
- 36 files changed, 932 insertions(+), 12 deletions(-)
+ 36 files changed, 935 insertions(+), 10 deletions(-)
 
 diff --git a/CONTRIBUTORS b/CONTRIBUTORS
 index 8724b7f3..8e29424e 100644
@@ -569,24 +568,30 @@ index 37fbc432..cf4ef7ef 100644
 +
  }  // namespace internal
  }  // namespace crashpad
- 
+
 diff --git a/snapshot/linux/debug_rendezvous_test.cc b/snapshot/linux/debug_rendezvous_test.cc
-index be22c903..c5df23d1 100644
+index 41956aa5d834..41e77cb9daf8 100644
 --- a/snapshot/linux/debug_rendezvous_test.cc
 +++ b/snapshot/linux/debug_rendezvous_test.cc
-@@ -159,9 +159,11 @@ void TestAgainstTarget(PtraceConnection* connection) {
-           const bool is_vdso_mapping =
-               device == 0 && inode == 0 && mapping_name == "[vdso]";
+@@ -193,10 +193,17 @@ void TestAgainstTarget(PtraceConnection* connection) {
+           static constexpr char kPrefix[] = "linux-gate.so.";
+ #else
            static constexpr char kPrefix[] = "linux-vdso.so.";
++#endif
++#if defined(ARCH_CPU_PPC64_FAMILY)
 +          static constexpr char kPrefix64[] = "linux-vdso64.so.";
+ #endif
            return is_vdso_mapping ==
                   (module_name.empty() ||
 -                  module_name.compare(0, strlen(kPrefix), kPrefix) == 0);
-+                  module_name.compare(0, strlen(kPrefix), kPrefix) == 0 ||
-+                  module_name.compare(0, strlen(kPrefix64), kPrefix64) == 0);
++                  module_name.compare(0, strlen(kPrefix), kPrefix) == 0 \
++#if defined(ARCH_CPU_PPC64_FAMILY)
++                  || module_name.compare(0, strlen(kPrefix64), kPrefix64) == 0
++#endif
++                  );
          },
          module_mapping->name,
-         module_mapping->device,
+         module_mapping->device, 
 diff --git a/snapshot/linux/exception_snapshot_linux.cc b/snapshot/linux/exception_snapshot_linux.cc
 index cd40b3b1..6bcf23b6 100644
 --- a/snapshot/linux/exception_snapshot_linux.cc
@@ -720,19 +725,6 @@ index c1d6c40f..8923b171 100644
  #else
  #error Port.
  #endif
-diff --git a/snapshot/linux/process_reader_linux_test.cc b/snapshot/linux/process_reader_linux_test.cc
-index e2e5566c..ee194c7c 100644
---- a/snapshot/linux/process_reader_linux_test.cc
-+++ b/snapshot/linux/process_reader_linux_test.cc
-@@ -591,6 +591,8 @@ bool WriteTestModule(const base::FilePath& module_path) {
-   module.ehdr.e_machine = EM_AARCH64;
- #elif defined(ARCH_CPU_MIPSEL) || defined(ARCH_CPU_MIPS64EL)
-   module.ehdr.e_machine = EM_MIPS;
-+#elif defined(ARCH_CPU_PPC64)
-+  module.ehdr.e_machine = EM_PPC64;
- #endif
- 
-   module.ehdr.e_version = EV_CURRENT;
 diff --git a/snapshot/linux/signal_context.h b/snapshot/linux/signal_context.h
 index 11002468..8e335a09 100644
 --- a/snapshot/linux/signal_context.h
@@ -1000,21 +992,6 @@ index d3d5ebdf..3fd730cb 100644
      if (!MapInsertOrReplace(&values_, type, value, nullptr)) {
        LOG(ERROR) << "duplicate auxv entry";
        return false;
-diff --git a/util/linux/ptrace_broker.cc b/util/linux/ptrace_broker.cc
-index 4d7e4ced..b9e08950 100644
---- a/util/linux/ptrace_broker.cc
-+++ b/util/linux/ptrace_broker.cc
-@@ -93,8 +93,8 @@ int PtraceBroker::Run() {
- }
- 
- bool PtraceBroker::AllocateAttachments() {
--  constexpr size_t page_size = 4096;
--  constexpr size_t alloc_size =
-+  static size_t page_size = getpagesize();
-+  size_t alloc_size =
-       (sizeof(ScopedPtraceAttach) + page_size - 1) & ~(page_size - 1);
-   void* alloc = sbrk(alloc_size);
-   if (reinterpret_cast<intptr_t>(alloc) == -1) {
 diff --git a/util/linux/ptracer.cc b/util/linux/ptracer.cc
 index c6c92299..c770b6b6 100644
 --- a/util/linux/ptracer.cc
@@ -1500,6 +1477,19 @@ index 9fc5db28..5f69f8dc 100644
  #endif
  }
  
+diff --git a/util/net/http_transport_libcurl.cc b/util/net/http_transport_libcurl.cc
+index 8993ebca1e88..291e7d0b9998 100644
+--- a/util/net/http_transport_libcurl.cc
++++ b/util/net/http_transport_libcurl.cc
+@@ -236,6 +236,8 @@ std::string UserAgent() {
+ #elif defined(ARCH_CPU_BIG_ENDIAN)
+     static constexpr char arch[] = "aarch64_be";
+ #endif
++#elif defined(ARCH_CPU_PPC64_FAMILY)
++    static constexpr char arch[] = "ppc64";
+ #else
+ #error Port
+ #endif
 diff --git a/util/posix/signals_test.cc b/util/posix/signals_test.cc
 index d91e3cc6..b1ffc7b1 100644
 --- a/util/posix/signals_test.cc

--- a/ffmpeg/0001-Add-support-for-ppc64.patch
+++ b/ffmpeg/0001-Add-support-for-ppc64.patch
@@ -14,16 +14,18 @@ diff --git a/chromium/scripts/build_ffmpeg.py b/chromium/scripts/build_ffmpeg.py
 index 309d7b9a00..ca316dd24d 100755
 --- a/chromium/scripts/build_ffmpeg.py
 +++ b/chromium/scripts/build_ffmpeg.py
-@@ -36,7 +36,7 @@
+@@ -39,9 +39,7 @@ BRANDINGS = [
+
+ ARCH_MAP = {
      'android': ['ia32', 'x64', 'arm-neon', 'arm64'],
-     'linux': [
-         'ia32', 'x64', 'mipsel', 'mips64el', 'noasm-x64', 'arm', 'arm-neon',
--        'arm64'
-+        'arm64', 'ppc64'
-     ],
-     'mac': ['x64'],
+-    'linux': [
+-        'ia32', 'x64', 'noasm-x64', 'arm', 'arm-neon', 'arm64'
+-    ],
++    'linux': [ 'ia32', 'x64', 'noasm-x64', 'arm', 'arm-neon', 'arm64', 'ppc64' ],
+     'mac': ['x64', 'arm64'],
      'win': ['ia32', 'x64', 'arm64'],
-@@ -128,6 +128,8 @@
+ }
+@@ -142,6 +140,8 @@ def DetermineHostOsAndArch():
      host_arch = 'mips64el'
    elif platform.machine().startswith('arm'):
      host_arch = 'arm'
@@ -31,8 +33,8 @@ index 309d7b9a00..ca316dd24d 100755
 +    host_arch = 'ppc64'
    else:
      return None
- 
-@@ -789,6 +791,11 @@
+
+@@ -920,6 +920,11 @@ def ConfigureAndBuild(target_arch, target_os, host_os, host_arch, parallel_jobs,
              '--extra-cflags=--target=mips64el-linux-gnuabi64',
              '--extra-ldflags=--target=mips64el-linux-gnuabi64',
          ])
@@ -44,14 +46,14 @@ index 309d7b9a00..ca316dd24d 100755
      else:
        print(
            'Error: Unknown target arch %r for target OS %r!' % (target_arch,
-@@ -814,7 +821,7 @@
+@@ -945,7 +950,7 @@ def ConfigureAndBuild(target_arch, target_os, host_os, host_arch, parallel_jobs,
      # typically be the system one, so explicitly configure use of Clang's
      # ld.lld, to ensure that things like cross-compilation and LTO work.
      # This does not work for ia32 and is always used on mac.
 -    if target_arch != 'ia32' and target_os != 'mac':
 +    if target_arch != 'ia32' and target_arch != 'ppc64' and target_os != 'mac':
        configure_flags['Common'].append('--extra-ldflags=-fuse-ld=lld')
- 
+
    # Should be run on Mac, unless we're cross-compiling on Linux.
 diff --git a/chromium/scripts/copy_config.sh b/chromium/scripts/copy_config.sh
 index 0e5159d6f4..7e4e8175f7 100755
@@ -67,34 +69,33 @@ index 0e5159d6f4..7e4e8175f7 100755
        [ ! -e "build.$arch.$os/$target/config.h" ] && continue
        for f in config.h config.asm libavutil/avconfig.h libavutil/ffversion.h libavcodec/bsf_list.c libavcodec/codec_list.c libavcodec/parser_list.c libavformat/demuxer_list.c libavformat/muxer_list.c libavformat/protocol_list.c; do
 diff --git a/chromium/scripts/generate_gn.py b/chromium/scripts/generate_gn.py
-index b4adb7f45c..7191648231 100755
+index 2f0c90eeae..09c88ff9ca 100755
 --- a/chromium/scripts/generate_gn.py
 +++ b/chromium/scripts/generate_gn.py
-@@ -77,7 +77,7 @@ GN_SOURCE_END = """]
- Attr = enum('ARCHITECTURE', 'TARGET', 'PLATFORM')
+@@ -76,7 +76,7 @@ _Attrs = ('ARCHITECTURE', 'TARGET', 'PLATFORM')
+ Attr = collections.namedtuple('Attr', _Attrs)(*_Attrs)
  SUPPORT_MATRIX = {
      Attr.ARCHITECTURE:
--        set(['ia32', 'x64', 'arm', 'arm64', 'arm-neon', 'mipsel', 'mips64el']),
-+        set(['ia32', 'x64', 'arm', 'arm64', 'arm-neon', 'mipsel', 'mips64el', 'ppc64']),
+-        set(['ia32', 'x64', 'arm', 'arm64', 'arm-neon']),
++        set(['ia32', 'x64', 'arm', 'arm64', 'arm-neon', 'ppc64']),
      Attr.TARGET:
          set(['Chromium', 'Chrome', 'ChromeOS']),
      Attr.PLATFORM:
 diff --git a/chromium/scripts/generate_gn_unittest.py b/chromium/scripts/generate_gn_unittest.py
-index c4c2faf614..4ba85171a2 100755
+index 880a697da6..148ca10e86 100755
 --- a/chromium/scripts/generate_gn_unittest.py
 +++ b/chromium/scripts/generate_gn_unittest.py
-@@ -324,6 +324,10 @@
+@@ -323,6 +323,9 @@ class SourceSetUnittest(unittest.TestCase):
      f = SourceSet(
          set(['common', 'arm-neon', 'chrome', 'chromeos']),
          set([SourceListCondition('arm-neon', 'ChromeOS', 'linux')]))
 +    g = SourceSet(
 +        set(['common']),
 +        set([SourceListCondition('ppc64', 'Chromium', 'linux')]))
-+
- 
+
      expected = set()
      expected.add(
-@@ -335,7 +339,8 @@
+@@ -334,7 +337,8 @@ class SourceSetUnittest(unittest.TestCase):
                  SourceListCondition('x64', 'Chromium', 'linux'),
                  SourceListCondition('x64', 'Chrome', 'linux'),
                  SourceListCondition('arm', 'Chromium', 'linux'),
@@ -104,23 +105,23 @@ index c4c2faf614..4ba85171a2 100755
              ])))
      expected.add(
          SourceSet(
-@@ -363,7 +368,7 @@
+@@ -362,7 +366,7 @@ class SourceSetUnittest(unittest.TestCase):
              set(['arm-neon', 'chromeos']),
              set([SourceListCondition('arm-neon', 'ChromeOS', 'linux')])))
- 
+
 -    source_sets = gg.CreatePairwiseDisjointSets([a, b, c, d, e, f])
 +    source_sets = gg.CreatePairwiseDisjointSets([a, b, c, d, e, f, g])
      self.assertEqualSourceSets(expected, set(source_sets))
- 
+
    def testReduceConditions(self):
-@@ -378,6 +383,7 @@
+@@ -375,6 +379,7 @@ class SourceSetUnittest(unittest.TestCase):
+             SourceListCondition('arm', 'Chromium', 'linux'),
+             SourceListCondition('arm64', 'Chromium', 'linux'),
              SourceListCondition('arm-neon', 'Chromium', 'linux'),
-             SourceListCondition('mipsel', 'Chromium', 'linux'),
-             SourceListCondition('mips64el', 'Chromium', 'linux'),
 +            SourceListCondition('ppc64', 'Chromium', 'linux'),
          ]))
      gg.ReduceConditionalLogic(a)
- 
--- 
+
+--
 2.17.1
 

--- a/libaom/0001-Add-pregenerated-config-for-libaom-on-ppc64.patch
+++ b/libaom/0001-Add-pregenerated-config-for-libaom-on-ppc64.patch
@@ -23,9 +23,9 @@ new file mode 100644
 index 0000000000..ec43beb4d0
 --- /dev/null
 +++ b/third_party/libaom/source/config/linux/ppc64/config/aom_config.asm
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,87 @@
 +;
-+; Copyright (c) 2019, Alliance for Open Media. All rights reserved
++; Copyright (c) 2021, Alliance for Open Media. All rights reserved
 +;
 +; This source code is subject to the terms of the BSD 2 Clause License and
 +; the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -36,18 +36,20 @@ index 0000000000..ec43beb4d0
 +;
 +ARCH_ARM equ 0
 +ARCH_MIPS equ 0
-+ARCH_PPC equ 1
++ARCH_PPC equ 0
 +ARCH_X86 equ 0
 +ARCH_X86_64 equ 0
-+CONFIG_2PASS_PARTITION_SEARCH_LVL equ 1
 +CONFIG_ACCOUNTING equ 0
 +CONFIG_ANALYZER equ 0
 +CONFIG_AV1_DECODER equ 1
-+CONFIG_AV1_ENCODER equ 0
++CONFIG_AV1_ENCODER equ 1
++CONFIG_AV1_HIGHBITDEPTH equ 0
++CONFIG_AV1_TEMPORAL_DENOISING equ 1
 +CONFIG_BIG_ENDIAN equ 0
++CONFIG_BITRATE_ACCURACY equ 0
 +CONFIG_BITSTREAM_DEBUG equ 0
 +CONFIG_COEFFICIENT_RANGE_CHECKING equ 0
-+CONFIG_COLLECT_INTER_MODE_RD_STATS equ 1
++CONFIG_COLLECT_COMPONENT_TIMING equ 0
 +CONFIG_COLLECT_PARTITION_STATS equ 0
 +CONFIG_COLLECT_RD_STATS equ 0
 +CONFIG_DEBUG equ 0
@@ -55,34 +57,40 @@ index 0000000000..ec43beb4d0
 +CONFIG_DISABLE_FULL_PIXEL_SPLIT_8X8 equ 1
 +CONFIG_DIST_8X8 equ 0
 +CONFIG_ENTROPY_STATS equ 0
-+CONFIG_FILEOPTIONS equ 1
-+CONFIG_FP_MB_STATS equ 0
++CONFIG_EXCLUDE_SIMD_MISMATCH equ 0
++CONFIG_FRAME_PARALLEL_ENCODE equ 0
 +CONFIG_GCC equ 1
 +CONFIG_GCOV equ 0
 +CONFIG_GPROF equ 0
 +CONFIG_INSPECTION equ 0
 +CONFIG_INTERNAL_STATS equ 0
 +CONFIG_INTER_STATS_ONLY equ 0
-+CONFIG_LIBYUV equ 1
-+CONFIG_LOWBITDEPTH equ 1
++CONFIG_LIBYUV equ 0
 +CONFIG_MAX_DECODE_PROFILE equ 0
 +CONFIG_MISMATCH_DEBUG equ 0
 +CONFIG_MULTITHREAD equ 1
++CONFIG_NN_V2 equ 0
 +CONFIG_NORMAL_TILE_MODE equ 1
-+CONFIG_ONE_PASS_SVM equ 0
++CONFIG_OPTICAL_FLOW_API equ 0
 +CONFIG_OS_SUPPORT equ 1
++CONFIG_PARTITION_SEARCH_ORDER equ 0
 +CONFIG_PIC equ 0
++CONFIG_RD_COMMAND equ 0
 +CONFIG_RD_DEBUG equ 0
-+CONFIG_RUNTIME_CPU_DETECT equ 0
++CONFIG_REALTIME_ONLY equ 1
++CONFIG_RT_ML_PARTITIONING equ 0
++CONFIG_RUNTIME_CPU_DETECT equ 1
 +CONFIG_SHARED equ 0
 +CONFIG_SHARP_SETTINGS equ 0
 +CONFIG_SIZE_LIMIT equ 1
 +CONFIG_SPATIAL_RESAMPLING equ 1
 +CONFIG_SPEED_STATS equ 0
-+CONFIG_STATIC equ 1
++CONFIG_TUNE_BUTTERAUGLI equ 0
++CONFIG_TUNE_VMAF equ 0
 +CONFIG_WEBM_IO equ 1
 +DECODE_HEIGHT_LIMIT equ 16384
 +DECODE_WIDTH_LIMIT equ 16384
++FORCE_HIGHBITDEPTH_DECODING equ 0
 +HAVE_AVX equ 0
 +HAVE_AVX2 equ 0
 +HAVE_DSPR2 equ 0
@@ -100,8 +108,9 @@ index 0000000000..ec43beb4d0
 +HAVE_SSE4_2 equ 0
 +HAVE_SSSE3 equ 0
 +HAVE_UNISTD_H equ 1
-+HAVE_VSX equ 1
++HAVE_VSX equ 0
 +HAVE_WXWIDGETS equ 0
++STATIC_LINK_JXL equ 0
 diff --git a/third_party/libaom/source/config/linux/ppc64/config/aom_config.c b/third_party/libaom/source/config/linux/ppc64/config/aom_config.c
 new file mode 100644
 index 0000000000..6db656662e
@@ -119,16 +128,16 @@ index 0000000000..6db656662e
 + * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 + */
 +#include "aom/aom_codec.h"
-+static const char* const cfg = "cmake ../source/libaom -G \"Unix Makefiles\" -DCMAKE_TOOLCHAIN_FILE=\"../source/libaom/build/cmake/toolchains/ppc-linux-gcc.cmake\" -DCONFIG_AV1_ENCODER=0 -DCONFIG_LOWBITDEPTH=1 -DCONFIG_MAX_DECODE_PROFILE=0 -DCONFIG_NORMAL_TILE_MODE=1 -DCONFIG_SIZE_LIMIT=1 -DDECODE_HEIGHT_LIMIT=16384 -DDECODE_WIDTH_LIMIT=16384";
++static const char* const cfg = "cmake ../source/libaom -G \"Unix Makefiles\" -DAOM_TARGET_CPU=generic -DCONFIG_AV1_ENCODER=1 -DCONFIG_LIBYUV=0 -DCONFIG_REALTIME_ONLY=1 -DCONFIG_AV1_HIGHBITDEPTH=0 -DCONFIG_AV1_TEMPORAL_DENOISING=1 -DCONFIG_MAX_DECODE_PROFILE=0 -DCONFIG_NORMAL_TILE_MODE=1 -DCONFIG_SIZE_LIMIT=1 -DDECODE_HEIGHT_LIMIT=16384 -DDECODE_WIDTH_LIMIT=16384";
 +const char *aom_codec_build_config(void) {return cfg;}
 diff --git a/third_party/libaom/source/config/linux/ppc64/config/aom_config.h b/third_party/libaom/source/config/linux/ppc64/config/aom_config.h
 new file mode 100644
 index 0000000000..ba5b7e55be
 --- /dev/null
 +++ b/third_party/libaom/source/config/linux/ppc64/config/aom_config.h
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,91 @@
 +/*
-+ * Copyright (c) 2019, Alliance for Open Media. All rights reserved
++ * Copyright (c) 2021, Alliance for Open Media. All rights reserved
 + *
 + * This source code is subject to the terms of the BSD 2 Clause License and
 + * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
@@ -141,18 +150,20 @@ index 0000000000..ba5b7e55be
 +#define AOM_CONFIG_H_
 +#define ARCH_ARM 0
 +#define ARCH_MIPS 0
-+#define ARCH_PPC 1
++#define ARCH_PPC 0
 +#define ARCH_X86 0
 +#define ARCH_X86_64 0
-+#define CONFIG_2PASS_PARTITION_SEARCH_LVL 1
 +#define CONFIG_ACCOUNTING 0
 +#define CONFIG_ANALYZER 0
 +#define CONFIG_AV1_DECODER 1
-+#define CONFIG_AV1_ENCODER 0
++#define CONFIG_AV1_ENCODER 1
++#define CONFIG_AV1_HIGHBITDEPTH 0
++#define CONFIG_AV1_TEMPORAL_DENOISING 1
 +#define CONFIG_BIG_ENDIAN 0
++#define CONFIG_BITRATE_ACCURACY 0
 +#define CONFIG_BITSTREAM_DEBUG 0
 +#define CONFIG_COEFFICIENT_RANGE_CHECKING 0
-+#define CONFIG_COLLECT_INTER_MODE_RD_STATS 1
++#define CONFIG_COLLECT_COMPONENT_TIMING 0
 +#define CONFIG_COLLECT_PARTITION_STATS 0
 +#define CONFIG_COLLECT_RD_STATS 0
 +#define CONFIG_DEBUG 0
@@ -160,34 +171,40 @@ index 0000000000..ba5b7e55be
 +#define CONFIG_DISABLE_FULL_PIXEL_SPLIT_8X8 1
 +#define CONFIG_DIST_8X8 0
 +#define CONFIG_ENTROPY_STATS 0
-+#define CONFIG_FILEOPTIONS 1
-+#define CONFIG_FP_MB_STATS 0
++#define CONFIG_EXCLUDE_SIMD_MISMATCH 0
++#define CONFIG_FRAME_PARALLEL_ENCODE 0
 +#define CONFIG_GCC 1
 +#define CONFIG_GCOV 0
 +#define CONFIG_GPROF 0
 +#define CONFIG_INSPECTION 0
 +#define CONFIG_INTERNAL_STATS 0
 +#define CONFIG_INTER_STATS_ONLY 0
-+#define CONFIG_LIBYUV 1
-+#define CONFIG_LOWBITDEPTH 1
++#define CONFIG_LIBYUV 0
 +#define CONFIG_MAX_DECODE_PROFILE 0
 +#define CONFIG_MISMATCH_DEBUG 0
 +#define CONFIG_MULTITHREAD 1
++#define CONFIG_NN_V2 0
 +#define CONFIG_NORMAL_TILE_MODE 1
-+#define CONFIG_ONE_PASS_SVM 0
++#define CONFIG_OPTICAL_FLOW_API 0
 +#define CONFIG_OS_SUPPORT 1
++#define CONFIG_PARTITION_SEARCH_ORDER 0
 +#define CONFIG_PIC 0
++#define CONFIG_RD_COMMAND 0
 +#define CONFIG_RD_DEBUG 0
-+#define CONFIG_RUNTIME_CPU_DETECT 0
++#define CONFIG_REALTIME_ONLY 1
++#define CONFIG_RT_ML_PARTITIONING 0
++#define CONFIG_RUNTIME_CPU_DETECT 1
 +#define CONFIG_SHARED 0
 +#define CONFIG_SHARP_SETTINGS 0
 +#define CONFIG_SIZE_LIMIT 1
 +#define CONFIG_SPATIAL_RESAMPLING 1
 +#define CONFIG_SPEED_STATS 0
-+#define CONFIG_STATIC 1
++#define CONFIG_TUNE_BUTTERAUGLI 0
++#define CONFIG_TUNE_VMAF 0
 +#define CONFIG_WEBM_IO 1
 +#define DECODE_HEIGHT_LIMIT 16384
 +#define DECODE_WIDTH_LIMIT 16384
++#define FORCE_HIGHBITDEPTH_DECODING 0
 +#define HAVE_AVX 0
 +#define HAVE_AVX2 0
 +#define HAVE_DSPR2 0
@@ -205,9 +222,10 @@ index 0000000000..ba5b7e55be
 +#define HAVE_SSE4_2 0
 +#define HAVE_SSSE3 0
 +#define HAVE_UNISTD_H 1
-+#define HAVE_VSX 1
++#define HAVE_VSX 0
 +#define HAVE_WXWIDGETS 0
 +#define INLINE inline
++#define STATIC_LINK_JXL 0
 +#endif  // AOM_CONFIG_H_
 diff --git a/third_party/libaom/source/config/linux/ppc64/config/aom_dsp_rtcd.h b/third_party/libaom/source/config/linux/ppc64/config/aom_dsp_rtcd.h
 new file mode 100644
@@ -238,6 +256,12 @@ index 0000000000..1969860e30
 +extern "C" {
 +#endif
 +
++unsigned int aom_avg_4x4_c(const uint8_t*, int p);
++#define aom_avg_4x4 aom_avg_4x4_c
++
++unsigned int aom_avg_8x8_c(const uint8_t*, int p);
++#define aom_avg_8x8 aom_avg_8x8_c
++
 +void aom_blend_a64_hmask_c(uint8_t* dst,
 +                           uint32_t dst_stride,
 +                           const uint8_t* src0,
@@ -259,8 +283,8 @@ index 0000000000..1969860e30
 +                          uint32_t mask_stride,
 +                          int w,
 +                          int h,
-+                          int subx,
-+                          int suby);
++                          int subw,
++                          int subh);
 +#define aom_blend_a64_mask aom_blend_a64_mask_c
 +
 +void aom_blend_a64_vmask_c(uint8_t* dst,
@@ -273,6 +297,73 @@ index 0000000000..1969860e30
 +                           int w,
 +                           int h);
 +#define aom_blend_a64_vmask aom_blend_a64_vmask_c
++
++void aom_comp_avg_pred_c(uint8_t* comp_pred,
++                         const uint8_t* pred,
++                         int width,
++                         int height,
++                         const uint8_t* ref,
++                         int ref_stride);
++#define aom_comp_avg_pred aom_comp_avg_pred_c
++
++void aom_comp_avg_upsampled_pred_c(MACROBLOCKD* xd,
++                                   const struct AV1Common* const cm,
++                                   int mi_row,
++                                   int mi_col,
++                                   const MV* const mv,
++                                   uint8_t* comp_pred,
++                                   const uint8_t* pred,
++                                   int width,
++                                   int height,
++                                   int subpel_x_q3,
++                                   int subpel_y_q3,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   int subpel_search);
++#define aom_comp_avg_upsampled_pred aom_comp_avg_upsampled_pred_c
++
++void aom_comp_mask_pred_c(uint8_t* comp_pred,
++                          const uint8_t* pred,
++                          int width,
++                          int height,
++                          const uint8_t* ref,
++                          int ref_stride,
++                          const uint8_t* mask,
++                          int mask_stride,
++                          int invert_mask);
++#define aom_comp_mask_pred aom_comp_mask_pred_c
++
++void aom_comp_mask_upsampled_pred_c(MACROBLOCKD* xd,
++                                    const struct AV1Common* const cm,
++                                    int mi_row,
++                                    int mi_col,
++                                    const MV* const mv,
++                                    uint8_t* comp_pred,
++                                    const uint8_t* pred,
++                                    int width,
++                                    int height,
++                                    int subpel_x_q3,
++                                    int subpel_y_q3,
++                                    const uint8_t* ref,
++                                    int ref_stride,
++                                    const uint8_t* mask,
++                                    int mask_stride,
++                                    int invert_mask,
++                                    int subpel_search);
++#define aom_comp_mask_upsampled_pred aom_comp_mask_upsampled_pred_c
++
++void aom_convolve8_c(const uint8_t* src,
++                     ptrdiff_t src_stride,
++                     uint8_t* dst,
++                     ptrdiff_t dst_stride,
++                     const InterpKernel* filter,
++                     int x0_q4,
++                     int x_step_q4,
++                     int y0_q4,
++                     int y_step_q4,
++                     int w,
++                     int h);
++#define aom_convolve8 aom_convolve8_c
 +
 +void aom_convolve8_horiz_c(const uint8_t* src,
 +                           ptrdiff_t src_stride,
@@ -302,10 +393,6 @@ index 0000000000..1969860e30
 +                         ptrdiff_t src_stride,
 +                         uint8_t* dst,
 +                         ptrdiff_t dst_stride,
-+                         const int16_t* filter_x,
-+                         int x_step_q4,
-+                         const int16_t* filter_y,
-+                         int y_step_q4,
 +                         int w,
 +                         int h);
 +#define aom_convolve_copy aom_convolve_copy_c
@@ -321,18 +408,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* above,
 +                                  const uint8_t* left);
 +#define aom_dc_128_predictor_16x32 aom_dc_128_predictor_16x32_c
-+
-+void aom_dc_128_predictor_16x4_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_128_predictor_16x4 aom_dc_128_predictor_16x4_c
-+
-+void aom_dc_128_predictor_16x64_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_128_predictor_16x64 aom_dc_128_predictor_16x64_c
 +
 +void aom_dc_128_predictor_16x8_c(uint8_t* dst,
 +                                 ptrdiff_t y_stride,
@@ -364,18 +439,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* left);
 +#define aom_dc_128_predictor_32x64 aom_dc_128_predictor_32x64_c
 +
-+void aom_dc_128_predictor_32x8_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_128_predictor_32x8 aom_dc_128_predictor_32x8_c
-+
-+void aom_dc_128_predictor_4x16_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_128_predictor_4x16 aom_dc_128_predictor_4x16_c
-+
 +void aom_dc_128_predictor_4x4_c(uint8_t* dst,
 +                                ptrdiff_t y_stride,
 +                                const uint8_t* above,
@@ -387,12 +450,6 @@ index 0000000000..1969860e30
 +                                const uint8_t* above,
 +                                const uint8_t* left);
 +#define aom_dc_128_predictor_4x8 aom_dc_128_predictor_4x8_c
-+
-+void aom_dc_128_predictor_64x16_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_128_predictor_64x16 aom_dc_128_predictor_64x16_c
 +
 +void aom_dc_128_predictor_64x32_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
@@ -411,12 +468,6 @@ index 0000000000..1969860e30
 +                                 const uint8_t* above,
 +                                 const uint8_t* left);
 +#define aom_dc_128_predictor_8x16 aom_dc_128_predictor_8x16_c
-+
-+void aom_dc_128_predictor_8x32_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_128_predictor_8x32 aom_dc_128_predictor_8x32_c
 +
 +void aom_dc_128_predictor_8x4_c(uint8_t* dst,
 +                                ptrdiff_t y_stride,
@@ -441,18 +492,6 @@ index 0000000000..1969860e30
 +                                   const uint8_t* above,
 +                                   const uint8_t* left);
 +#define aom_dc_left_predictor_16x32 aom_dc_left_predictor_16x32_c
-+
-+void aom_dc_left_predictor_16x4_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_left_predictor_16x4 aom_dc_left_predictor_16x4_c
-+
-+void aom_dc_left_predictor_16x64_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_dc_left_predictor_16x64 aom_dc_left_predictor_16x64_c
 +
 +void aom_dc_left_predictor_16x8_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
@@ -484,18 +523,6 @@ index 0000000000..1969860e30
 +                                   const uint8_t* left);
 +#define aom_dc_left_predictor_32x64 aom_dc_left_predictor_32x64_c
 +
-+void aom_dc_left_predictor_32x8_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_left_predictor_32x8 aom_dc_left_predictor_32x8_c
-+
-+void aom_dc_left_predictor_4x16_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_left_predictor_4x16 aom_dc_left_predictor_4x16_c
-+
 +void aom_dc_left_predictor_4x4_c(uint8_t* dst,
 +                                 ptrdiff_t y_stride,
 +                                 const uint8_t* above,
@@ -507,12 +534,6 @@ index 0000000000..1969860e30
 +                                 const uint8_t* above,
 +                                 const uint8_t* left);
 +#define aom_dc_left_predictor_4x8 aom_dc_left_predictor_4x8_c
-+
-+void aom_dc_left_predictor_64x16_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_dc_left_predictor_64x16 aom_dc_left_predictor_64x16_c
 +
 +void aom_dc_left_predictor_64x32_c(uint8_t* dst,
 +                                   ptrdiff_t y_stride,
@@ -531,12 +552,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* above,
 +                                  const uint8_t* left);
 +#define aom_dc_left_predictor_8x16 aom_dc_left_predictor_8x16_c
-+
-+void aom_dc_left_predictor_8x32_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_left_predictor_8x32 aom_dc_left_predictor_8x32_c
 +
 +void aom_dc_left_predictor_8x4_c(uint8_t* dst,
 +                                 ptrdiff_t y_stride,
@@ -561,18 +576,6 @@ index 0000000000..1969860e30
 +                              const uint8_t* above,
 +                              const uint8_t* left);
 +#define aom_dc_predictor_16x32 aom_dc_predictor_16x32_c
-+
-+void aom_dc_predictor_16x4_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_dc_predictor_16x4 aom_dc_predictor_16x4_c
-+
-+void aom_dc_predictor_16x64_c(uint8_t* dst,
-+                              ptrdiff_t y_stride,
-+                              const uint8_t* above,
-+                              const uint8_t* left);
-+#define aom_dc_predictor_16x64 aom_dc_predictor_16x64_c
 +
 +void aom_dc_predictor_16x8_c(uint8_t* dst,
 +                             ptrdiff_t y_stride,
@@ -604,18 +607,6 @@ index 0000000000..1969860e30
 +                              const uint8_t* left);
 +#define aom_dc_predictor_32x64 aom_dc_predictor_32x64_c
 +
-+void aom_dc_predictor_32x8_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_dc_predictor_32x8 aom_dc_predictor_32x8_c
-+
-+void aom_dc_predictor_4x16_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_dc_predictor_4x16 aom_dc_predictor_4x16_c
-+
 +void aom_dc_predictor_4x4_c(uint8_t* dst,
 +                            ptrdiff_t y_stride,
 +                            const uint8_t* above,
@@ -627,12 +618,6 @@ index 0000000000..1969860e30
 +                            const uint8_t* above,
 +                            const uint8_t* left);
 +#define aom_dc_predictor_4x8 aom_dc_predictor_4x8_c
-+
-+void aom_dc_predictor_64x16_c(uint8_t* dst,
-+                              ptrdiff_t y_stride,
-+                              const uint8_t* above,
-+                              const uint8_t* left);
-+#define aom_dc_predictor_64x16 aom_dc_predictor_64x16_c
 +
 +void aom_dc_predictor_64x32_c(uint8_t* dst,
 +                              ptrdiff_t y_stride,
@@ -651,12 +636,6 @@ index 0000000000..1969860e30
 +                             const uint8_t* above,
 +                             const uint8_t* left);
 +#define aom_dc_predictor_8x16 aom_dc_predictor_8x16_c
-+
-+void aom_dc_predictor_8x32_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_dc_predictor_8x32 aom_dc_predictor_8x32_c
 +
 +void aom_dc_predictor_8x4_c(uint8_t* dst,
 +                            ptrdiff_t y_stride,
@@ -681,18 +660,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* above,
 +                                  const uint8_t* left);
 +#define aom_dc_top_predictor_16x32 aom_dc_top_predictor_16x32_c
-+
-+void aom_dc_top_predictor_16x4_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_top_predictor_16x4 aom_dc_top_predictor_16x4_c
-+
-+void aom_dc_top_predictor_16x64_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_top_predictor_16x64 aom_dc_top_predictor_16x64_c
 +
 +void aom_dc_top_predictor_16x8_c(uint8_t* dst,
 +                                 ptrdiff_t y_stride,
@@ -724,18 +691,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* left);
 +#define aom_dc_top_predictor_32x64 aom_dc_top_predictor_32x64_c
 +
-+void aom_dc_top_predictor_32x8_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_top_predictor_32x8 aom_dc_top_predictor_32x8_c
-+
-+void aom_dc_top_predictor_4x16_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_top_predictor_4x16 aom_dc_top_predictor_4x16_c
-+
 +void aom_dc_top_predictor_4x4_c(uint8_t* dst,
 +                                ptrdiff_t y_stride,
 +                                const uint8_t* above,
@@ -747,12 +702,6 @@ index 0000000000..1969860e30
 +                                const uint8_t* above,
 +                                const uint8_t* left);
 +#define aom_dc_top_predictor_4x8 aom_dc_top_predictor_4x8_c
-+
-+void aom_dc_top_predictor_64x16_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_dc_top_predictor_64x16 aom_dc_top_predictor_64x16_c
 +
 +void aom_dc_top_predictor_64x32_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
@@ -772,12 +721,6 @@ index 0000000000..1969860e30
 +                                 const uint8_t* left);
 +#define aom_dc_top_predictor_8x16 aom_dc_top_predictor_8x16_c
 +
-+void aom_dc_top_predictor_8x32_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_dc_top_predictor_8x32 aom_dc_top_predictor_8x32_c
-+
 +void aom_dc_top_predictor_8x4_c(uint8_t* dst,
 +                                ptrdiff_t y_stride,
 +                                const uint8_t* above,
@@ -790,6 +733,430 @@ index 0000000000..1969860e30
 +                                const uint8_t* left);
 +#define aom_dc_top_predictor_8x8 aom_dc_top_predictor_8x8_c
 +
++void aom_dist_wtd_comp_avg_pred_c(uint8_t* comp_pred,
++                                  const uint8_t* pred,
++                                  int width,
++                                  int height,
++                                  const uint8_t* ref,
++                                  int ref_stride,
++                                  const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_comp_avg_pred aom_dist_wtd_comp_avg_pred_c
++
++void aom_dist_wtd_comp_avg_upsampled_pred_c(
++    MACROBLOCKD* xd,
++    const struct AV1Common* const cm,
++    int mi_row,
++    int mi_col,
++    const MV* const mv,
++    uint8_t* comp_pred,
++    const uint8_t* pred,
++    int width,
++    int height,
++    int subpel_x_q3,
++    int subpel_y_q3,
++    const uint8_t* ref,
++    int ref_stride,
++    const DIST_WTD_COMP_PARAMS* jcp_param,
++    int subpel_search);
++#define aom_dist_wtd_comp_avg_upsampled_pred \
++  aom_dist_wtd_comp_avg_upsampled_pred_c
++
++unsigned int aom_dist_wtd_sad128x128_avg_c(
++    const uint8_t* src_ptr,
++    int src_stride,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad128x128_avg aom_dist_wtd_sad128x128_avg_c
++
++unsigned int aom_dist_wtd_sad128x64_avg_c(
++    const uint8_t* src_ptr,
++    int src_stride,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad128x64_avg aom_dist_wtd_sad128x64_avg_c
++
++unsigned int aom_dist_wtd_sad16x16_avg_c(const uint8_t* src_ptr,
++                                         int src_stride,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         const uint8_t* second_pred,
++                                         const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad16x16_avg aom_dist_wtd_sad16x16_avg_c
++
++unsigned int aom_dist_wtd_sad16x32_avg_c(const uint8_t* src_ptr,
++                                         int src_stride,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         const uint8_t* second_pred,
++                                         const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad16x32_avg aom_dist_wtd_sad16x32_avg_c
++
++unsigned int aom_dist_wtd_sad16x8_avg_c(const uint8_t* src_ptr,
++                                        int src_stride,
++                                        const uint8_t* ref_ptr,
++                                        int ref_stride,
++                                        const uint8_t* second_pred,
++                                        const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad16x8_avg aom_dist_wtd_sad16x8_avg_c
++
++unsigned int aom_dist_wtd_sad32x16_avg_c(const uint8_t* src_ptr,
++                                         int src_stride,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         const uint8_t* second_pred,
++                                         const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad32x16_avg aom_dist_wtd_sad32x16_avg_c
++
++unsigned int aom_dist_wtd_sad32x32_avg_c(const uint8_t* src_ptr,
++                                         int src_stride,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         const uint8_t* second_pred,
++                                         const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad32x32_avg aom_dist_wtd_sad32x32_avg_c
++
++unsigned int aom_dist_wtd_sad32x64_avg_c(const uint8_t* src_ptr,
++                                         int src_stride,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         const uint8_t* second_pred,
++                                         const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad32x64_avg aom_dist_wtd_sad32x64_avg_c
++
++unsigned int aom_dist_wtd_sad4x4_avg_c(const uint8_t* src_ptr,
++                                       int src_stride,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       const uint8_t* second_pred,
++                                       const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad4x4_avg aom_dist_wtd_sad4x4_avg_c
++
++unsigned int aom_dist_wtd_sad4x8_avg_c(const uint8_t* src_ptr,
++                                       int src_stride,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       const uint8_t* second_pred,
++                                       const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad4x8_avg aom_dist_wtd_sad4x8_avg_c
++
++unsigned int aom_dist_wtd_sad64x128_avg_c(
++    const uint8_t* src_ptr,
++    int src_stride,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad64x128_avg aom_dist_wtd_sad64x128_avg_c
++
++unsigned int aom_dist_wtd_sad64x32_avg_c(const uint8_t* src_ptr,
++                                         int src_stride,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         const uint8_t* second_pred,
++                                         const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad64x32_avg aom_dist_wtd_sad64x32_avg_c
++
++unsigned int aom_dist_wtd_sad64x64_avg_c(const uint8_t* src_ptr,
++                                         int src_stride,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         const uint8_t* second_pred,
++                                         const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad64x64_avg aom_dist_wtd_sad64x64_avg_c
++
++unsigned int aom_dist_wtd_sad8x16_avg_c(const uint8_t* src_ptr,
++                                        int src_stride,
++                                        const uint8_t* ref_ptr,
++                                        int ref_stride,
++                                        const uint8_t* second_pred,
++                                        const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad8x16_avg aom_dist_wtd_sad8x16_avg_c
++
++unsigned int aom_dist_wtd_sad8x4_avg_c(const uint8_t* src_ptr,
++                                       int src_stride,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       const uint8_t* second_pred,
++                                       const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad8x4_avg aom_dist_wtd_sad8x4_avg_c
++
++unsigned int aom_dist_wtd_sad8x8_avg_c(const uint8_t* src_ptr,
++                                       int src_stride,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       const uint8_t* second_pred,
++                                       const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sad8x8_avg aom_dist_wtd_sad8x8_avg_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance128x128_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance128x128 \
++  aom_dist_wtd_sub_pixel_avg_variance128x128_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance128x64_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance128x64 \
++  aom_dist_wtd_sub_pixel_avg_variance128x64_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance16x16_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance16x16 \
++  aom_dist_wtd_sub_pixel_avg_variance16x16_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance16x32_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance16x32 \
++  aom_dist_wtd_sub_pixel_avg_variance16x32_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance16x8_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance16x8 \
++  aom_dist_wtd_sub_pixel_avg_variance16x8_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance32x16_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance32x16 \
++  aom_dist_wtd_sub_pixel_avg_variance32x16_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance32x32_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance32x32 \
++  aom_dist_wtd_sub_pixel_avg_variance32x32_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance32x64_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance32x64 \
++  aom_dist_wtd_sub_pixel_avg_variance32x64_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance4x4_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance4x4 \
++  aom_dist_wtd_sub_pixel_avg_variance4x4_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance4x8_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance4x8 \
++  aom_dist_wtd_sub_pixel_avg_variance4x8_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance64x128_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance64x128 \
++  aom_dist_wtd_sub_pixel_avg_variance64x128_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance64x32_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance64x32 \
++  aom_dist_wtd_sub_pixel_avg_variance64x32_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance64x64_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance64x64 \
++  aom_dist_wtd_sub_pixel_avg_variance64x64_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance8x16_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance8x16 \
++  aom_dist_wtd_sub_pixel_avg_variance8x16_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance8x4_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance8x4 \
++  aom_dist_wtd_sub_pixel_avg_variance8x4_c
++
++uint32_t aom_dist_wtd_sub_pixel_avg_variance8x8_c(
++    const uint8_t* src_ptr,
++    int source_stride,
++    int xoffset,
++    int yoffset,
++    const uint8_t* ref_ptr,
++    int ref_stride,
++    uint32_t* sse,
++    const uint8_t* second_pred,
++    const DIST_WTD_COMP_PARAMS* jcp_param);
++#define aom_dist_wtd_sub_pixel_avg_variance8x8 \
++  aom_dist_wtd_sub_pixel_avg_variance8x8_c
++
++void aom_fdct4x4_c(const int16_t* input, tran_low_t* output, int stride);
++#define aom_fdct4x4 aom_fdct4x4_c
++
++void aom_fdct4x4_lp_c(const int16_t* input, int16_t* output, int stride);
++#define aom_fdct4x4_lp aom_fdct4x4_lp_c
++
++void aom_fdct8x8_c(const int16_t* input, tran_low_t* output, int stride);
++#define aom_fdct8x8 aom_fdct8x8_c
++
++void aom_fft16x16_float_c(const float* input, float* temp, float* output);
++#define aom_fft16x16_float aom_fft16x16_float_c
++
++void aom_fft2x2_float_c(const float* input, float* temp, float* output);
++#define aom_fft2x2_float aom_fft2x2_float_c
++
++void aom_fft32x32_float_c(const float* input, float* temp, float* output);
++#define aom_fft32x32_float aom_fft32x32_float_c
++
++void aom_fft4x4_float_c(const float* input, float* temp, float* output);
++#define aom_fft4x4_float aom_fft4x4_float_c
++
++void aom_fft8x8_float_c(const float* input, float* temp, float* output);
++#define aom_fft8x8_float aom_fft8x8_float_c
++
++void aom_get16x16var_c(const uint8_t* src_ptr,
++                       int source_stride,
++                       const uint8_t* ref_ptr,
++                       int ref_stride,
++                       unsigned int* sse,
++                       int* sum);
++#define aom_get16x16var aom_get16x16var_c
++
++unsigned int aom_get4x4sse_cs_c(const unsigned char* src_ptr,
++                                int source_stride,
++                                const unsigned char* ref_ptr,
++                                int ref_stride);
++#define aom_get4x4sse_cs aom_get4x4sse_cs_c
++
++void aom_get8x8var_c(const uint8_t* src_ptr,
++                     int source_stride,
++                     const uint8_t* ref_ptr,
++                     int ref_stride,
++                     unsigned int* sse,
++                     int* sum);
++#define aom_get8x8var aom_get8x8var_c
++
++void aom_get_blk_sse_sum_c(const int16_t* data,
++                           int stride,
++                           int bw,
++                           int bh,
++                           int* x_sum,
++                           int64_t* x2_sum);
++#define aom_get_blk_sse_sum aom_get_blk_sse_sum_c
++
++unsigned int aom_get_mb_ss_c(const int16_t*);
++#define aom_get_mb_ss aom_get_mb_ss_c
++
 +void aom_h_predictor_16x16_c(uint8_t* dst,
 +                             ptrdiff_t y_stride,
 +                             const uint8_t* above,
@@ -801,18 +1168,6 @@ index 0000000000..1969860e30
 +                             const uint8_t* above,
 +                             const uint8_t* left);
 +#define aom_h_predictor_16x32 aom_h_predictor_16x32_c
-+
-+void aom_h_predictor_16x4_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_h_predictor_16x4 aom_h_predictor_16x4_c
-+
-+void aom_h_predictor_16x64_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_h_predictor_16x64 aom_h_predictor_16x64_c
 +
 +void aom_h_predictor_16x8_c(uint8_t* dst,
 +                            ptrdiff_t y_stride,
@@ -844,18 +1199,6 @@ index 0000000000..1969860e30
 +                             const uint8_t* left);
 +#define aom_h_predictor_32x64 aom_h_predictor_32x64_c
 +
-+void aom_h_predictor_32x8_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_h_predictor_32x8 aom_h_predictor_32x8_c
-+
-+void aom_h_predictor_4x16_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_h_predictor_4x16 aom_h_predictor_4x16_c
-+
 +void aom_h_predictor_4x4_c(uint8_t* dst,
 +                           ptrdiff_t y_stride,
 +                           const uint8_t* above,
@@ -867,12 +1210,6 @@ index 0000000000..1969860e30
 +                           const uint8_t* above,
 +                           const uint8_t* left);
 +#define aom_h_predictor_4x8 aom_h_predictor_4x8_c
-+
-+void aom_h_predictor_64x16_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_h_predictor_64x16 aom_h_predictor_64x16_c
 +
 +void aom_h_predictor_64x32_c(uint8_t* dst,
 +                             ptrdiff_t y_stride,
@@ -892,12 +1229,6 @@ index 0000000000..1969860e30
 +                            const uint8_t* left);
 +#define aom_h_predictor_8x16 aom_h_predictor_8x16_c
 +
-+void aom_h_predictor_8x32_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_h_predictor_8x32 aom_h_predictor_8x32_c
-+
 +void aom_h_predictor_8x4_c(uint8_t* dst,
 +                           ptrdiff_t y_stride,
 +                           const uint8_t* above,
@@ -910,1669 +1241,59 @@ index 0000000000..1969860e30
 +                           const uint8_t* left);
 +#define aom_h_predictor_8x8 aom_h_predictor_8x8_c
 +
-+void aom_highbd_blend_a64_d16_mask_c(uint8_t* dst,
-+                                     uint32_t dst_stride,
-+                                     const CONV_BUF_TYPE* src0,
-+                                     uint32_t src0_stride,
-+                                     const CONV_BUF_TYPE* src1,
-+                                     uint32_t src1_stride,
-+                                     const uint8_t* mask,
-+                                     uint32_t mask_stride,
-+                                     int w,
-+                                     int h,
-+                                     int subx,
-+                                     int suby,
-+                                     ConvolveParams* conv_params,
-+                                     const int bd);
-+#define aom_highbd_blend_a64_d16_mask aom_highbd_blend_a64_d16_mask_c
-+
-+void aom_highbd_blend_a64_hmask_c(uint8_t* dst,
-+                                  uint32_t dst_stride,
-+                                  const uint8_t* src0,
-+                                  uint32_t src0_stride,
-+                                  const uint8_t* src1,
-+                                  uint32_t src1_stride,
-+                                  const uint8_t* mask,
-+                                  int w,
-+                                  int h,
-+                                  int bd);
-+#define aom_highbd_blend_a64_hmask aom_highbd_blend_a64_hmask_c
-+
-+void aom_highbd_blend_a64_mask_c(uint8_t* dst,
-+                                 uint32_t dst_stride,
-+                                 const uint8_t* src0,
-+                                 uint32_t src0_stride,
-+                                 const uint8_t* src1,
-+                                 uint32_t src1_stride,
-+                                 const uint8_t* mask,
-+                                 uint32_t mask_stride,
-+                                 int w,
-+                                 int h,
-+                                 int subx,
-+                                 int suby,
-+                                 int bd);
-+#define aom_highbd_blend_a64_mask aom_highbd_blend_a64_mask_c
-+
-+void aom_highbd_blend_a64_vmask_c(uint8_t* dst,
-+                                  uint32_t dst_stride,
-+                                  const uint8_t* src0,
-+                                  uint32_t src0_stride,
-+                                  const uint8_t* src1,
-+                                  uint32_t src1_stride,
-+                                  const uint8_t* mask,
-+                                  int w,
-+                                  int h,
-+                                  int bd);
-+#define aom_highbd_blend_a64_vmask aom_highbd_blend_a64_vmask_c
-+
-+void aom_highbd_convolve8_horiz_c(const uint8_t* src,
-+                                  ptrdiff_t src_stride,
-+                                  uint8_t* dst,
-+                                  ptrdiff_t dst_stride,
-+                                  const int16_t* filter_x,
-+                                  int x_step_q4,
-+                                  const int16_t* filter_y,
-+                                  int y_step_q4,
-+                                  int w,
-+                                  int h,
-+                                  int bps);
-+#define aom_highbd_convolve8_horiz aom_highbd_convolve8_horiz_c
-+
-+void aom_highbd_convolve8_vert_c(const uint8_t* src,
-+                                 ptrdiff_t src_stride,
-+                                 uint8_t* dst,
-+                                 ptrdiff_t dst_stride,
-+                                 const int16_t* filter_x,
-+                                 int x_step_q4,
-+                                 const int16_t* filter_y,
-+                                 int y_step_q4,
-+                                 int w,
-+                                 int h,
-+                                 int bps);
-+#define aom_highbd_convolve8_vert aom_highbd_convolve8_vert_c
-+
-+void aom_highbd_convolve_copy_c(const uint8_t* src,
-+                                ptrdiff_t src_stride,
-+                                uint8_t* dst,
-+                                ptrdiff_t dst_stride,
-+                                const int16_t* filter_x,
-+                                int x_step_q4,
-+                                const int16_t* filter_y,
-+                                int y_step_q4,
-+                                int w,
-+                                int h,
-+                                int bps);
-+#define aom_highbd_convolve_copy aom_highbd_convolve_copy_c
-+
-+void aom_highbd_dc_128_predictor_16x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_16x16 aom_highbd_dc_128_predictor_16x16_c
-+
-+void aom_highbd_dc_128_predictor_16x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_16x32 aom_highbd_dc_128_predictor_16x32_c
-+
-+void aom_highbd_dc_128_predictor_16x4_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_128_predictor_16x4 aom_highbd_dc_128_predictor_16x4_c
-+
-+void aom_highbd_dc_128_predictor_16x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_16x64 aom_highbd_dc_128_predictor_16x64_c
-+
-+void aom_highbd_dc_128_predictor_16x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_128_predictor_16x8 aom_highbd_dc_128_predictor_16x8_c
-+
-+void aom_highbd_dc_128_predictor_2x2_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_128_predictor_2x2 aom_highbd_dc_128_predictor_2x2_c
-+
-+void aom_highbd_dc_128_predictor_32x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_32x16 aom_highbd_dc_128_predictor_32x16_c
-+
-+void aom_highbd_dc_128_predictor_32x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_32x32 aom_highbd_dc_128_predictor_32x32_c
-+
-+void aom_highbd_dc_128_predictor_32x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_32x64 aom_highbd_dc_128_predictor_32x64_c
-+
-+void aom_highbd_dc_128_predictor_32x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_128_predictor_32x8 aom_highbd_dc_128_predictor_32x8_c
-+
-+void aom_highbd_dc_128_predictor_4x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_128_predictor_4x16 aom_highbd_dc_128_predictor_4x16_c
-+
-+void aom_highbd_dc_128_predictor_4x4_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_128_predictor_4x4 aom_highbd_dc_128_predictor_4x4_c
-+
-+void aom_highbd_dc_128_predictor_4x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_128_predictor_4x8 aom_highbd_dc_128_predictor_4x8_c
-+
-+void aom_highbd_dc_128_predictor_64x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_64x16 aom_highbd_dc_128_predictor_64x16_c
-+
-+void aom_highbd_dc_128_predictor_64x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_64x32 aom_highbd_dc_128_predictor_64x32_c
-+
-+void aom_highbd_dc_128_predictor_64x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_128_predictor_64x64 aom_highbd_dc_128_predictor_64x64_c
-+
-+void aom_highbd_dc_128_predictor_8x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_128_predictor_8x16 aom_highbd_dc_128_predictor_8x16_c
-+
-+void aom_highbd_dc_128_predictor_8x32_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_128_predictor_8x32 aom_highbd_dc_128_predictor_8x32_c
-+
-+void aom_highbd_dc_128_predictor_8x4_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_128_predictor_8x4 aom_highbd_dc_128_predictor_8x4_c
-+
-+void aom_highbd_dc_128_predictor_8x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_128_predictor_8x8 aom_highbd_dc_128_predictor_8x8_c
-+
-+void aom_highbd_dc_left_predictor_16x16_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_16x16 aom_highbd_dc_left_predictor_16x16_c
-+
-+void aom_highbd_dc_left_predictor_16x32_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_16x32 aom_highbd_dc_left_predictor_16x32_c
-+
-+void aom_highbd_dc_left_predictor_16x4_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_left_predictor_16x4 aom_highbd_dc_left_predictor_16x4_c
-+
-+void aom_highbd_dc_left_predictor_16x64_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_16x64 aom_highbd_dc_left_predictor_16x64_c
-+
-+void aom_highbd_dc_left_predictor_16x8_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_left_predictor_16x8 aom_highbd_dc_left_predictor_16x8_c
-+
-+void aom_highbd_dc_left_predictor_2x2_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_left_predictor_2x2 aom_highbd_dc_left_predictor_2x2_c
-+
-+void aom_highbd_dc_left_predictor_32x16_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_32x16 aom_highbd_dc_left_predictor_32x16_c
-+
-+void aom_highbd_dc_left_predictor_32x32_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_32x32 aom_highbd_dc_left_predictor_32x32_c
-+
-+void aom_highbd_dc_left_predictor_32x64_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_32x64 aom_highbd_dc_left_predictor_32x64_c
-+
-+void aom_highbd_dc_left_predictor_32x8_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_left_predictor_32x8 aom_highbd_dc_left_predictor_32x8_c
-+
-+void aom_highbd_dc_left_predictor_4x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_left_predictor_4x16 aom_highbd_dc_left_predictor_4x16_c
-+
-+void aom_highbd_dc_left_predictor_4x4_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_left_predictor_4x4 aom_highbd_dc_left_predictor_4x4_c
-+
-+void aom_highbd_dc_left_predictor_4x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_left_predictor_4x8 aom_highbd_dc_left_predictor_4x8_c
-+
-+void aom_highbd_dc_left_predictor_64x16_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_64x16 aom_highbd_dc_left_predictor_64x16_c
-+
-+void aom_highbd_dc_left_predictor_64x32_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_64x32 aom_highbd_dc_left_predictor_64x32_c
-+
-+void aom_highbd_dc_left_predictor_64x64_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_dc_left_predictor_64x64 aom_highbd_dc_left_predictor_64x64_c
-+
-+void aom_highbd_dc_left_predictor_8x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_left_predictor_8x16 aom_highbd_dc_left_predictor_8x16_c
-+
-+void aom_highbd_dc_left_predictor_8x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_left_predictor_8x32 aom_highbd_dc_left_predictor_8x32_c
-+
-+void aom_highbd_dc_left_predictor_8x4_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_left_predictor_8x4 aom_highbd_dc_left_predictor_8x4_c
-+
-+void aom_highbd_dc_left_predictor_8x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_left_predictor_8x8 aom_highbd_dc_left_predictor_8x8_c
-+
-+void aom_highbd_dc_predictor_16x16_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_16x16 aom_highbd_dc_predictor_16x16_c
-+
-+void aom_highbd_dc_predictor_16x32_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_16x32 aom_highbd_dc_predictor_16x32_c
-+
-+void aom_highbd_dc_predictor_16x4_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_dc_predictor_16x4 aom_highbd_dc_predictor_16x4_c
-+
-+void aom_highbd_dc_predictor_16x64_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_16x64 aom_highbd_dc_predictor_16x64_c
-+
-+void aom_highbd_dc_predictor_16x8_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_dc_predictor_16x8 aom_highbd_dc_predictor_16x8_c
-+
-+void aom_highbd_dc_predictor_2x2_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_dc_predictor_2x2 aom_highbd_dc_predictor_2x2_c
-+
-+void aom_highbd_dc_predictor_32x16_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_32x16 aom_highbd_dc_predictor_32x16_c
-+
-+void aom_highbd_dc_predictor_32x32_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_32x32 aom_highbd_dc_predictor_32x32_c
-+
-+void aom_highbd_dc_predictor_32x64_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_32x64 aom_highbd_dc_predictor_32x64_c
-+
-+void aom_highbd_dc_predictor_32x8_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_dc_predictor_32x8 aom_highbd_dc_predictor_32x8_c
-+
-+void aom_highbd_dc_predictor_4x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_dc_predictor_4x16 aom_highbd_dc_predictor_4x16_c
-+
-+void aom_highbd_dc_predictor_4x4_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_dc_predictor_4x4 aom_highbd_dc_predictor_4x4_c
-+
-+void aom_highbd_dc_predictor_4x8_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_dc_predictor_4x8 aom_highbd_dc_predictor_4x8_c
-+
-+void aom_highbd_dc_predictor_64x16_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_64x16 aom_highbd_dc_predictor_64x16_c
-+
-+void aom_highbd_dc_predictor_64x32_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_64x32 aom_highbd_dc_predictor_64x32_c
-+
-+void aom_highbd_dc_predictor_64x64_c(uint16_t* dst,
-+                                     ptrdiff_t y_stride,
-+                                     const uint16_t* above,
-+                                     const uint16_t* left,
-+                                     int bd);
-+#define aom_highbd_dc_predictor_64x64 aom_highbd_dc_predictor_64x64_c
-+
-+void aom_highbd_dc_predictor_8x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_dc_predictor_8x16 aom_highbd_dc_predictor_8x16_c
-+
-+void aom_highbd_dc_predictor_8x32_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_dc_predictor_8x32 aom_highbd_dc_predictor_8x32_c
-+
-+void aom_highbd_dc_predictor_8x4_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_dc_predictor_8x4 aom_highbd_dc_predictor_8x4_c
-+
-+void aom_highbd_dc_predictor_8x8_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_dc_predictor_8x8 aom_highbd_dc_predictor_8x8_c
-+
-+void aom_highbd_dc_top_predictor_16x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_16x16 aom_highbd_dc_top_predictor_16x16_c
-+
-+void aom_highbd_dc_top_predictor_16x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_16x32 aom_highbd_dc_top_predictor_16x32_c
-+
-+void aom_highbd_dc_top_predictor_16x4_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_top_predictor_16x4 aom_highbd_dc_top_predictor_16x4_c
-+
-+void aom_highbd_dc_top_predictor_16x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_16x64 aom_highbd_dc_top_predictor_16x64_c
-+
-+void aom_highbd_dc_top_predictor_16x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_top_predictor_16x8 aom_highbd_dc_top_predictor_16x8_c
-+
-+void aom_highbd_dc_top_predictor_2x2_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_top_predictor_2x2 aom_highbd_dc_top_predictor_2x2_c
-+
-+void aom_highbd_dc_top_predictor_32x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_32x16 aom_highbd_dc_top_predictor_32x16_c
-+
-+void aom_highbd_dc_top_predictor_32x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_32x32 aom_highbd_dc_top_predictor_32x32_c
-+
-+void aom_highbd_dc_top_predictor_32x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_32x64 aom_highbd_dc_top_predictor_32x64_c
-+
-+void aom_highbd_dc_top_predictor_32x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_top_predictor_32x8 aom_highbd_dc_top_predictor_32x8_c
-+
-+void aom_highbd_dc_top_predictor_4x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_top_predictor_4x16 aom_highbd_dc_top_predictor_4x16_c
-+
-+void aom_highbd_dc_top_predictor_4x4_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_top_predictor_4x4 aom_highbd_dc_top_predictor_4x4_c
-+
-+void aom_highbd_dc_top_predictor_4x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_top_predictor_4x8 aom_highbd_dc_top_predictor_4x8_c
-+
-+void aom_highbd_dc_top_predictor_64x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_64x16 aom_highbd_dc_top_predictor_64x16_c
-+
-+void aom_highbd_dc_top_predictor_64x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_64x32 aom_highbd_dc_top_predictor_64x32_c
-+
-+void aom_highbd_dc_top_predictor_64x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_dc_top_predictor_64x64 aom_highbd_dc_top_predictor_64x64_c
-+
-+void aom_highbd_dc_top_predictor_8x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_top_predictor_8x16 aom_highbd_dc_top_predictor_8x16_c
-+
-+void aom_highbd_dc_top_predictor_8x32_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_dc_top_predictor_8x32 aom_highbd_dc_top_predictor_8x32_c
-+
-+void aom_highbd_dc_top_predictor_8x4_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_top_predictor_8x4 aom_highbd_dc_top_predictor_8x4_c
-+
-+void aom_highbd_dc_top_predictor_8x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_dc_top_predictor_8x8 aom_highbd_dc_top_predictor_8x8_c
-+
-+void aom_highbd_h_predictor_16x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_16x16 aom_highbd_h_predictor_16x16_c
-+
-+void aom_highbd_h_predictor_16x32_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_16x32 aom_highbd_h_predictor_16x32_c
-+
-+void aom_highbd_h_predictor_16x4_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_h_predictor_16x4 aom_highbd_h_predictor_16x4_c
-+
-+void aom_highbd_h_predictor_16x64_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_16x64 aom_highbd_h_predictor_16x64_c
-+
-+void aom_highbd_h_predictor_16x8_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_h_predictor_16x8 aom_highbd_h_predictor_16x8_c
-+
-+void aom_highbd_h_predictor_2x2_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_h_predictor_2x2 aom_highbd_h_predictor_2x2_c
-+
-+void aom_highbd_h_predictor_32x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_32x16 aom_highbd_h_predictor_32x16_c
-+
-+void aom_highbd_h_predictor_32x32_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_32x32 aom_highbd_h_predictor_32x32_c
-+
-+void aom_highbd_h_predictor_32x64_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_32x64 aom_highbd_h_predictor_32x64_c
-+
-+void aom_highbd_h_predictor_32x8_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_h_predictor_32x8 aom_highbd_h_predictor_32x8_c
-+
-+void aom_highbd_h_predictor_4x16_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_h_predictor_4x16 aom_highbd_h_predictor_4x16_c
-+
-+void aom_highbd_h_predictor_4x4_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_h_predictor_4x4 aom_highbd_h_predictor_4x4_c
-+
-+void aom_highbd_h_predictor_4x8_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_h_predictor_4x8 aom_highbd_h_predictor_4x8_c
-+
-+void aom_highbd_h_predictor_64x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_64x16 aom_highbd_h_predictor_64x16_c
-+
-+void aom_highbd_h_predictor_64x32_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_64x32 aom_highbd_h_predictor_64x32_c
-+
-+void aom_highbd_h_predictor_64x64_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_h_predictor_64x64 aom_highbd_h_predictor_64x64_c
-+
-+void aom_highbd_h_predictor_8x16_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_h_predictor_8x16 aom_highbd_h_predictor_8x16_c
-+
-+void aom_highbd_h_predictor_8x32_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_h_predictor_8x32 aom_highbd_h_predictor_8x32_c
-+
-+void aom_highbd_h_predictor_8x4_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_h_predictor_8x4 aom_highbd_h_predictor_8x4_c
-+
-+void aom_highbd_h_predictor_8x8_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_h_predictor_8x8 aom_highbd_h_predictor_8x8_c
-+
-+void aom_highbd_lpf_horizontal_14_c(uint16_t* s,
-+                                    int pitch,
-+                                    const uint8_t* blimit,
-+                                    const uint8_t* limit,
-+                                    const uint8_t* thresh,
-+                                    int bd);
-+#define aom_highbd_lpf_horizontal_14 aom_highbd_lpf_horizontal_14_c
-+
-+void aom_highbd_lpf_horizontal_14_dual_c(uint16_t* s,
-+                                         int pitch,
-+                                         const uint8_t* blimit0,
-+                                         const uint8_t* limit0,
-+                                         const uint8_t* thresh0,
-+                                         const uint8_t* blimit1,
-+                                         const uint8_t* limt1,
-+                                         const uint8_t* thresh1,
-+                                         int bd);
-+#define aom_highbd_lpf_horizontal_14_dual aom_highbd_lpf_horizontal_14_dual_c
-+
-+void aom_highbd_lpf_horizontal_4_c(uint16_t* s,
-+                                   int pitch,
-+                                   const uint8_t* blimit,
-+                                   const uint8_t* limit,
-+                                   const uint8_t* thresh,
-+                                   int bd);
-+#define aom_highbd_lpf_horizontal_4 aom_highbd_lpf_horizontal_4_c
-+
-+void aom_highbd_lpf_horizontal_4_dual_c(uint16_t* s,
-+                                        int pitch,
-+                                        const uint8_t* blimit0,
-+                                        const uint8_t* limit0,
-+                                        const uint8_t* thresh0,
-+                                        const uint8_t* blimit1,
-+                                        const uint8_t* limit1,
-+                                        const uint8_t* thresh1,
-+                                        int bd);
-+#define aom_highbd_lpf_horizontal_4_dual aom_highbd_lpf_horizontal_4_dual_c
-+
-+void aom_highbd_lpf_horizontal_6_c(uint16_t* s,
-+                                   int pitch,
-+                                   const uint8_t* blimit,
-+                                   const uint8_t* limit,
-+                                   const uint8_t* thresh,
-+                                   int bd);
-+#define aom_highbd_lpf_horizontal_6 aom_highbd_lpf_horizontal_6_c
-+
-+void aom_highbd_lpf_horizontal_6_dual_c(uint16_t* s,
-+                                        int pitch,
-+                                        const uint8_t* blimit0,
-+                                        const uint8_t* limit0,
-+                                        const uint8_t* thresh0,
-+                                        const uint8_t* blimit1,
-+                                        const uint8_t* limit1,
-+                                        const uint8_t* thresh1,
-+                                        int bd);
-+#define aom_highbd_lpf_horizontal_6_dual aom_highbd_lpf_horizontal_6_dual_c
-+
-+void aom_highbd_lpf_horizontal_8_c(uint16_t* s,
-+                                   int pitch,
-+                                   const uint8_t* blimit,
-+                                   const uint8_t* limit,
-+                                   const uint8_t* thresh,
-+                                   int bd);
-+#define aom_highbd_lpf_horizontal_8 aom_highbd_lpf_horizontal_8_c
-+
-+void aom_highbd_lpf_horizontal_8_dual_c(uint16_t* s,
-+                                        int pitch,
-+                                        const uint8_t* blimit0,
-+                                        const uint8_t* limit0,
-+                                        const uint8_t* thresh0,
-+                                        const uint8_t* blimit1,
-+                                        const uint8_t* limit1,
-+                                        const uint8_t* thresh1,
-+                                        int bd);
-+#define aom_highbd_lpf_horizontal_8_dual aom_highbd_lpf_horizontal_8_dual_c
-+
-+void aom_highbd_lpf_vertical_14_c(uint16_t* s,
-+                                  int pitch,
-+                                  const uint8_t* blimit,
-+                                  const uint8_t* limit,
-+                                  const uint8_t* thresh,
-+                                  int bd);
-+#define aom_highbd_lpf_vertical_14 aom_highbd_lpf_vertical_14_c
-+
-+void aom_highbd_lpf_vertical_14_dual_c(uint16_t* s,
-+                                       int pitch,
-+                                       const uint8_t* blimit0,
-+                                       const uint8_t* limit0,
-+                                       const uint8_t* thresh0,
-+                                       const uint8_t* blimit1,
-+                                       const uint8_t* limit1,
-+                                       const uint8_t* thresh1,
-+                                       int bd);
-+#define aom_highbd_lpf_vertical_14_dual aom_highbd_lpf_vertical_14_dual_c
-+
-+void aom_highbd_lpf_vertical_4_c(uint16_t* s,
-+                                 int pitch,
-+                                 const uint8_t* blimit,
-+                                 const uint8_t* limit,
-+                                 const uint8_t* thresh,
-+                                 int bd);
-+#define aom_highbd_lpf_vertical_4 aom_highbd_lpf_vertical_4_c
-+
-+void aom_highbd_lpf_vertical_4_dual_c(uint16_t* s,
-+                                      int pitch,
-+                                      const uint8_t* blimit0,
-+                                      const uint8_t* limit0,
-+                                      const uint8_t* thresh0,
-+                                      const uint8_t* blimit1,
-+                                      const uint8_t* limit1,
-+                                      const uint8_t* thresh1,
-+                                      int bd);
-+#define aom_highbd_lpf_vertical_4_dual aom_highbd_lpf_vertical_4_dual_c
-+
-+void aom_highbd_lpf_vertical_6_c(uint16_t* s,
-+                                 int pitch,
-+                                 const uint8_t* blimit,
-+                                 const uint8_t* limit,
-+                                 const uint8_t* thresh,
-+                                 int bd);
-+#define aom_highbd_lpf_vertical_6 aom_highbd_lpf_vertical_6_c
-+
-+void aom_highbd_lpf_vertical_6_dual_c(uint16_t* s,
-+                                      int pitch,
-+                                      const uint8_t* blimit0,
-+                                      const uint8_t* limit0,
-+                                      const uint8_t* thresh0,
-+                                      const uint8_t* blimit1,
-+                                      const uint8_t* limit1,
-+                                      const uint8_t* thresh1,
-+                                      int bd);
-+#define aom_highbd_lpf_vertical_6_dual aom_highbd_lpf_vertical_6_dual_c
-+
-+void aom_highbd_lpf_vertical_8_c(uint16_t* s,
-+                                 int pitch,
-+                                 const uint8_t* blimit,
-+                                 const uint8_t* limit,
-+                                 const uint8_t* thresh,
-+                                 int bd);
-+#define aom_highbd_lpf_vertical_8 aom_highbd_lpf_vertical_8_c
-+
-+void aom_highbd_lpf_vertical_8_dual_c(uint16_t* s,
-+                                      int pitch,
-+                                      const uint8_t* blimit0,
-+                                      const uint8_t* limit0,
-+                                      const uint8_t* thresh0,
-+                                      const uint8_t* blimit1,
-+                                      const uint8_t* limit1,
-+                                      const uint8_t* thresh1,
-+                                      int bd);
-+#define aom_highbd_lpf_vertical_8_dual aom_highbd_lpf_vertical_8_dual_c
-+
-+void aom_highbd_paeth_predictor_16x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_16x16 aom_highbd_paeth_predictor_16x16_c
-+
-+void aom_highbd_paeth_predictor_16x32_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_16x32 aom_highbd_paeth_predictor_16x32_c
-+
-+void aom_highbd_paeth_predictor_16x4_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_paeth_predictor_16x4 aom_highbd_paeth_predictor_16x4_c
-+
-+void aom_highbd_paeth_predictor_16x64_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_16x64 aom_highbd_paeth_predictor_16x64_c
-+
-+void aom_highbd_paeth_predictor_16x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_paeth_predictor_16x8 aom_highbd_paeth_predictor_16x8_c
-+
-+void aom_highbd_paeth_predictor_2x2_c(uint16_t* dst,
-+                                      ptrdiff_t y_stride,
-+                                      const uint16_t* above,
-+                                      const uint16_t* left,
-+                                      int bd);
-+#define aom_highbd_paeth_predictor_2x2 aom_highbd_paeth_predictor_2x2_c
-+
-+void aom_highbd_paeth_predictor_32x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_32x16 aom_highbd_paeth_predictor_32x16_c
-+
-+void aom_highbd_paeth_predictor_32x32_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_32x32 aom_highbd_paeth_predictor_32x32_c
-+
-+void aom_highbd_paeth_predictor_32x64_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_32x64 aom_highbd_paeth_predictor_32x64_c
-+
-+void aom_highbd_paeth_predictor_32x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_paeth_predictor_32x8 aom_highbd_paeth_predictor_32x8_c
-+
-+void aom_highbd_paeth_predictor_4x16_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_paeth_predictor_4x16 aom_highbd_paeth_predictor_4x16_c
-+
-+void aom_highbd_paeth_predictor_4x4_c(uint16_t* dst,
-+                                      ptrdiff_t y_stride,
-+                                      const uint16_t* above,
-+                                      const uint16_t* left,
-+                                      int bd);
-+#define aom_highbd_paeth_predictor_4x4 aom_highbd_paeth_predictor_4x4_c
-+
-+void aom_highbd_paeth_predictor_4x8_c(uint16_t* dst,
-+                                      ptrdiff_t y_stride,
-+                                      const uint16_t* above,
-+                                      const uint16_t* left,
-+                                      int bd);
-+#define aom_highbd_paeth_predictor_4x8 aom_highbd_paeth_predictor_4x8_c
-+
-+void aom_highbd_paeth_predictor_64x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_64x16 aom_highbd_paeth_predictor_64x16_c
-+
-+void aom_highbd_paeth_predictor_64x32_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_64x32 aom_highbd_paeth_predictor_64x32_c
-+
-+void aom_highbd_paeth_predictor_64x64_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_paeth_predictor_64x64 aom_highbd_paeth_predictor_64x64_c
-+
-+void aom_highbd_paeth_predictor_8x16_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_paeth_predictor_8x16 aom_highbd_paeth_predictor_8x16_c
-+
-+void aom_highbd_paeth_predictor_8x32_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_paeth_predictor_8x32 aom_highbd_paeth_predictor_8x32_c
-+
-+void aom_highbd_paeth_predictor_8x4_c(uint16_t* dst,
-+                                      ptrdiff_t y_stride,
-+                                      const uint16_t* above,
-+                                      const uint16_t* left,
-+                                      int bd);
-+#define aom_highbd_paeth_predictor_8x4 aom_highbd_paeth_predictor_8x4_c
-+
-+void aom_highbd_paeth_predictor_8x8_c(uint16_t* dst,
-+                                      ptrdiff_t y_stride,
-+                                      const uint16_t* above,
-+                                      const uint16_t* left,
-+                                      int bd);
-+#define aom_highbd_paeth_predictor_8x8 aom_highbd_paeth_predictor_8x8_c
-+
-+void aom_highbd_smooth_h_predictor_16x16_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_16x16 \
-+  aom_highbd_smooth_h_predictor_16x16_c
-+
-+void aom_highbd_smooth_h_predictor_16x32_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_16x32 \
-+  aom_highbd_smooth_h_predictor_16x32_c
-+
-+void aom_highbd_smooth_h_predictor_16x4_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_h_predictor_16x4 aom_highbd_smooth_h_predictor_16x4_c
-+
-+void aom_highbd_smooth_h_predictor_16x64_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_16x64 \
-+  aom_highbd_smooth_h_predictor_16x64_c
-+
-+void aom_highbd_smooth_h_predictor_16x8_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_h_predictor_16x8 aom_highbd_smooth_h_predictor_16x8_c
-+
-+void aom_highbd_smooth_h_predictor_2x2_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_h_predictor_2x2 aom_highbd_smooth_h_predictor_2x2_c
-+
-+void aom_highbd_smooth_h_predictor_32x16_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_32x16 \
-+  aom_highbd_smooth_h_predictor_32x16_c
-+
-+void aom_highbd_smooth_h_predictor_32x32_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_32x32 \
-+  aom_highbd_smooth_h_predictor_32x32_c
-+
-+void aom_highbd_smooth_h_predictor_32x64_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_32x64 \
-+  aom_highbd_smooth_h_predictor_32x64_c
-+
-+void aom_highbd_smooth_h_predictor_32x8_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_h_predictor_32x8 aom_highbd_smooth_h_predictor_32x8_c
-+
-+void aom_highbd_smooth_h_predictor_4x16_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_h_predictor_4x16 aom_highbd_smooth_h_predictor_4x16_c
-+
-+void aom_highbd_smooth_h_predictor_4x4_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_h_predictor_4x4 aom_highbd_smooth_h_predictor_4x4_c
-+
-+void aom_highbd_smooth_h_predictor_4x8_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_h_predictor_4x8 aom_highbd_smooth_h_predictor_4x8_c
-+
-+void aom_highbd_smooth_h_predictor_64x16_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_64x16 \
-+  aom_highbd_smooth_h_predictor_64x16_c
-+
-+void aom_highbd_smooth_h_predictor_64x32_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_64x32 \
-+  aom_highbd_smooth_h_predictor_64x32_c
-+
-+void aom_highbd_smooth_h_predictor_64x64_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_h_predictor_64x64 \
-+  aom_highbd_smooth_h_predictor_64x64_c
-+
-+void aom_highbd_smooth_h_predictor_8x16_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_h_predictor_8x16 aom_highbd_smooth_h_predictor_8x16_c
-+
-+void aom_highbd_smooth_h_predictor_8x32_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_h_predictor_8x32 aom_highbd_smooth_h_predictor_8x32_c
-+
-+void aom_highbd_smooth_h_predictor_8x4_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_h_predictor_8x4 aom_highbd_smooth_h_predictor_8x4_c
-+
-+void aom_highbd_smooth_h_predictor_8x8_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_h_predictor_8x8 aom_highbd_smooth_h_predictor_8x8_c
-+
-+void aom_highbd_smooth_predictor_16x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_16x16 aom_highbd_smooth_predictor_16x16_c
-+
-+void aom_highbd_smooth_predictor_16x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_16x32 aom_highbd_smooth_predictor_16x32_c
-+
-+void aom_highbd_smooth_predictor_16x4_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_smooth_predictor_16x4 aom_highbd_smooth_predictor_16x4_c
-+
-+void aom_highbd_smooth_predictor_16x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_16x64 aom_highbd_smooth_predictor_16x64_c
-+
-+void aom_highbd_smooth_predictor_16x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_smooth_predictor_16x8 aom_highbd_smooth_predictor_16x8_c
-+
-+void aom_highbd_smooth_predictor_2x2_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_smooth_predictor_2x2 aom_highbd_smooth_predictor_2x2_c
-+
-+void aom_highbd_smooth_predictor_32x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_32x16 aom_highbd_smooth_predictor_32x16_c
-+
-+void aom_highbd_smooth_predictor_32x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_32x32 aom_highbd_smooth_predictor_32x32_c
-+
-+void aom_highbd_smooth_predictor_32x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_32x64 aom_highbd_smooth_predictor_32x64_c
-+
-+void aom_highbd_smooth_predictor_32x8_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_smooth_predictor_32x8 aom_highbd_smooth_predictor_32x8_c
-+
-+void aom_highbd_smooth_predictor_4x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_smooth_predictor_4x16 aom_highbd_smooth_predictor_4x16_c
-+
-+void aom_highbd_smooth_predictor_4x4_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_smooth_predictor_4x4 aom_highbd_smooth_predictor_4x4_c
-+
-+void aom_highbd_smooth_predictor_4x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_smooth_predictor_4x8 aom_highbd_smooth_predictor_4x8_c
-+
-+void aom_highbd_smooth_predictor_64x16_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_64x16 aom_highbd_smooth_predictor_64x16_c
-+
-+void aom_highbd_smooth_predictor_64x32_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_64x32 aom_highbd_smooth_predictor_64x32_c
-+
-+void aom_highbd_smooth_predictor_64x64_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_predictor_64x64 aom_highbd_smooth_predictor_64x64_c
-+
-+void aom_highbd_smooth_predictor_8x16_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_smooth_predictor_8x16 aom_highbd_smooth_predictor_8x16_c
-+
-+void aom_highbd_smooth_predictor_8x32_c(uint16_t* dst,
-+                                        ptrdiff_t y_stride,
-+                                        const uint16_t* above,
-+                                        const uint16_t* left,
-+                                        int bd);
-+#define aom_highbd_smooth_predictor_8x32 aom_highbd_smooth_predictor_8x32_c
-+
-+void aom_highbd_smooth_predictor_8x4_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_smooth_predictor_8x4 aom_highbd_smooth_predictor_8x4_c
-+
-+void aom_highbd_smooth_predictor_8x8_c(uint16_t* dst,
-+                                       ptrdiff_t y_stride,
-+                                       const uint16_t* above,
-+                                       const uint16_t* left,
-+                                       int bd);
-+#define aom_highbd_smooth_predictor_8x8 aom_highbd_smooth_predictor_8x8_c
-+
-+void aom_highbd_smooth_v_predictor_16x16_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_16x16 \
-+  aom_highbd_smooth_v_predictor_16x16_c
-+
-+void aom_highbd_smooth_v_predictor_16x32_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_16x32 \
-+  aom_highbd_smooth_v_predictor_16x32_c
-+
-+void aom_highbd_smooth_v_predictor_16x4_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_v_predictor_16x4 aom_highbd_smooth_v_predictor_16x4_c
-+
-+void aom_highbd_smooth_v_predictor_16x64_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_16x64 \
-+  aom_highbd_smooth_v_predictor_16x64_c
-+
-+void aom_highbd_smooth_v_predictor_16x8_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_v_predictor_16x8 aom_highbd_smooth_v_predictor_16x8_c
-+
-+void aom_highbd_smooth_v_predictor_2x2_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_v_predictor_2x2 aom_highbd_smooth_v_predictor_2x2_c
-+
-+void aom_highbd_smooth_v_predictor_32x16_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_32x16 \
-+  aom_highbd_smooth_v_predictor_32x16_c
-+
-+void aom_highbd_smooth_v_predictor_32x32_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_32x32 \
-+  aom_highbd_smooth_v_predictor_32x32_c
-+
-+void aom_highbd_smooth_v_predictor_32x64_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_32x64 \
-+  aom_highbd_smooth_v_predictor_32x64_c
-+
-+void aom_highbd_smooth_v_predictor_32x8_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_v_predictor_32x8 aom_highbd_smooth_v_predictor_32x8_c
-+
-+void aom_highbd_smooth_v_predictor_4x16_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_v_predictor_4x16 aom_highbd_smooth_v_predictor_4x16_c
-+
-+void aom_highbd_smooth_v_predictor_4x4_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_v_predictor_4x4 aom_highbd_smooth_v_predictor_4x4_c
-+
-+void aom_highbd_smooth_v_predictor_4x8_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_v_predictor_4x8 aom_highbd_smooth_v_predictor_4x8_c
-+
-+void aom_highbd_smooth_v_predictor_64x16_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_64x16 \
-+  aom_highbd_smooth_v_predictor_64x16_c
-+
-+void aom_highbd_smooth_v_predictor_64x32_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_64x32 \
-+  aom_highbd_smooth_v_predictor_64x32_c
-+
-+void aom_highbd_smooth_v_predictor_64x64_c(uint16_t* dst,
-+                                           ptrdiff_t y_stride,
-+                                           const uint16_t* above,
-+                                           const uint16_t* left,
-+                                           int bd);
-+#define aom_highbd_smooth_v_predictor_64x64 \
-+  aom_highbd_smooth_v_predictor_64x64_c
-+
-+void aom_highbd_smooth_v_predictor_8x16_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_v_predictor_8x16 aom_highbd_smooth_v_predictor_8x16_c
-+
-+void aom_highbd_smooth_v_predictor_8x32_c(uint16_t* dst,
-+                                          ptrdiff_t y_stride,
-+                                          const uint16_t* above,
-+                                          const uint16_t* left,
-+                                          int bd);
-+#define aom_highbd_smooth_v_predictor_8x32 aom_highbd_smooth_v_predictor_8x32_c
-+
-+void aom_highbd_smooth_v_predictor_8x4_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_v_predictor_8x4 aom_highbd_smooth_v_predictor_8x4_c
-+
-+void aom_highbd_smooth_v_predictor_8x8_c(uint16_t* dst,
-+                                         ptrdiff_t y_stride,
-+                                         const uint16_t* above,
-+                                         const uint16_t* left,
-+                                         int bd);
-+#define aom_highbd_smooth_v_predictor_8x8 aom_highbd_smooth_v_predictor_8x8_c
-+
-+void aom_highbd_v_predictor_16x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_16x16 aom_highbd_v_predictor_16x16_c
-+
-+void aom_highbd_v_predictor_16x32_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_16x32 aom_highbd_v_predictor_16x32_c
-+
-+void aom_highbd_v_predictor_16x4_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_v_predictor_16x4 aom_highbd_v_predictor_16x4_c
-+
-+void aom_highbd_v_predictor_16x64_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_16x64 aom_highbd_v_predictor_16x64_c
-+
-+void aom_highbd_v_predictor_16x8_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_v_predictor_16x8 aom_highbd_v_predictor_16x8_c
-+
-+void aom_highbd_v_predictor_2x2_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_v_predictor_2x2 aom_highbd_v_predictor_2x2_c
-+
-+void aom_highbd_v_predictor_32x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_32x16 aom_highbd_v_predictor_32x16_c
-+
-+void aom_highbd_v_predictor_32x32_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_32x32 aom_highbd_v_predictor_32x32_c
-+
-+void aom_highbd_v_predictor_32x64_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_32x64 aom_highbd_v_predictor_32x64_c
-+
-+void aom_highbd_v_predictor_32x8_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_v_predictor_32x8 aom_highbd_v_predictor_32x8_c
-+
-+void aom_highbd_v_predictor_4x16_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_v_predictor_4x16 aom_highbd_v_predictor_4x16_c
-+
-+void aom_highbd_v_predictor_4x4_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_v_predictor_4x4 aom_highbd_v_predictor_4x4_c
-+
-+void aom_highbd_v_predictor_4x8_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_v_predictor_4x8 aom_highbd_v_predictor_4x8_c
-+
-+void aom_highbd_v_predictor_64x16_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_64x16 aom_highbd_v_predictor_64x16_c
-+
-+void aom_highbd_v_predictor_64x32_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_64x32 aom_highbd_v_predictor_64x32_c
-+
-+void aom_highbd_v_predictor_64x64_c(uint16_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint16_t* above,
-+                                    const uint16_t* left,
-+                                    int bd);
-+#define aom_highbd_v_predictor_64x64 aom_highbd_v_predictor_64x64_c
-+
-+void aom_highbd_v_predictor_8x16_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_v_predictor_8x16 aom_highbd_v_predictor_8x16_c
-+
-+void aom_highbd_v_predictor_8x32_c(uint16_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int bd);
-+#define aom_highbd_v_predictor_8x32 aom_highbd_v_predictor_8x32_c
-+
-+void aom_highbd_v_predictor_8x4_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_v_predictor_8x4 aom_highbd_v_predictor_8x4_c
-+
-+void aom_highbd_v_predictor_8x8_c(uint16_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint16_t* above,
-+                                  const uint16_t* left,
-+                                  int bd);
-+#define aom_highbd_v_predictor_8x8 aom_highbd_v_predictor_8x8_c
++void aom_hadamard_16x16_c(const int16_t* src_diff,
++                          ptrdiff_t src_stride,
++                          tran_low_t* coeff);
++#define aom_hadamard_16x16 aom_hadamard_16x16_c
++
++void aom_hadamard_32x32_c(const int16_t* src_diff,
++                          ptrdiff_t src_stride,
++                          tran_low_t* coeff);
++#define aom_hadamard_32x32 aom_hadamard_32x32_c
++
++void aom_hadamard_4x4_c(const int16_t* src_diff,
++                        ptrdiff_t src_stride,
++                        tran_low_t* coeff);
++#define aom_hadamard_4x4 aom_hadamard_4x4_c
++
++void aom_hadamard_8x8_c(const int16_t* src_diff,
++                        ptrdiff_t src_stride,
++                        tran_low_t* coeff);
++#define aom_hadamard_8x8 aom_hadamard_8x8_c
++
++void aom_hadamard_lp_16x16_c(const int16_t* src_diff,
++                             ptrdiff_t src_stride,
++                             int16_t* coeff);
++#define aom_hadamard_lp_16x16 aom_hadamard_lp_16x16_c
++
++void aom_hadamard_lp_8x8_c(const int16_t* src_diff,
++                           ptrdiff_t src_stride,
++                           int16_t* coeff);
++#define aom_hadamard_lp_8x8 aom_hadamard_lp_8x8_c
++
++void aom_ifft16x16_float_c(const float* input, float* temp, float* output);
++#define aom_ifft16x16_float aom_ifft16x16_float_c
++
++void aom_ifft2x2_float_c(const float* input, float* temp, float* output);
++#define aom_ifft2x2_float aom_ifft2x2_float_c
++
++void aom_ifft32x32_float_c(const float* input, float* temp, float* output);
++#define aom_ifft32x32_float aom_ifft32x32_float_c
++
++void aom_ifft4x4_float_c(const float* input, float* temp, float* output);
++#define aom_ifft4x4_float aom_ifft4x4_float_c
++
++void aom_ifft8x8_float_c(const float* input, float* temp, float* output);
++#define aom_ifft8x8_float aom_ifft8x8_float_c
++
++int16_t aom_int_pro_col_c(const uint8_t* ref, const int width);
++#define aom_int_pro_col aom_int_pro_col_c
++
++void aom_int_pro_row_c(int16_t* hbuf,
++                       const uint8_t* ref,
++                       const int ref_stride,
++                       const int height);
++#define aom_int_pro_row aom_int_pro_row_c
 +
 +void aom_lowbd_blend_a64_d16_mask_c(uint8_t* dst,
 +                                    uint32_t dst_stride,
@@ -2584,8 +1305,8 @@ index 0000000000..1969860e30
 +                                    uint32_t mask_stride,
 +                                    int w,
 +                                    int h,
-+                                    int subx,
-+                                    int suby,
++                                    int subw,
++                                    int subh,
 +                                    ConvolveParams* conv_params);
 +#define aom_lowbd_blend_a64_d16_mask aom_lowbd_blend_a64_d16_mask_c
 +
@@ -2725,6 +1446,597 @@ index 0000000000..1969860e30
 +                               const uint8_t* thresh1);
 +#define aom_lpf_vertical_8_dual aom_lpf_vertical_8_dual_c
 +
++unsigned int aom_masked_sad128x128_c(const uint8_t* src,
++                                     int src_stride,
++                                     const uint8_t* ref,
++                                     int ref_stride,
++                                     const uint8_t* second_pred,
++                                     const uint8_t* msk,
++                                     int msk_stride,
++                                     int invert_mask);
++#define aom_masked_sad128x128 aom_masked_sad128x128_c
++
++void aom_masked_sad128x128x4d_c(const uint8_t* src,
++                                int src_stride,
++                                const uint8_t* ref[],
++                                int ref_stride,
++                                const uint8_t* second_pred,
++                                const uint8_t* msk,
++                                int msk_stride,
++                                int invert_mask,
++                                unsigned sads[]);
++#define aom_masked_sad128x128x4d aom_masked_sad128x128x4d_c
++
++unsigned int aom_masked_sad128x64_c(const uint8_t* src,
++                                    int src_stride,
++                                    const uint8_t* ref,
++                                    int ref_stride,
++                                    const uint8_t* second_pred,
++                                    const uint8_t* msk,
++                                    int msk_stride,
++                                    int invert_mask);
++#define aom_masked_sad128x64 aom_masked_sad128x64_c
++
++void aom_masked_sad128x64x4d_c(const uint8_t* src,
++                               int src_stride,
++                               const uint8_t* ref[],
++                               int ref_stride,
++                               const uint8_t* second_pred,
++                               const uint8_t* msk,
++                               int msk_stride,
++                               int invert_mask,
++                               unsigned sads[]);
++#define aom_masked_sad128x64x4d aom_masked_sad128x64x4d_c
++
++unsigned int aom_masked_sad16x16_c(const uint8_t* src,
++                                   int src_stride,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   const uint8_t* second_pred,
++                                   const uint8_t* msk,
++                                   int msk_stride,
++                                   int invert_mask);
++#define aom_masked_sad16x16 aom_masked_sad16x16_c
++
++void aom_masked_sad16x16x4d_c(const uint8_t* src,
++                              int src_stride,
++                              const uint8_t* ref[],
++                              int ref_stride,
++                              const uint8_t* second_pred,
++                              const uint8_t* msk,
++                              int msk_stride,
++                              int invert_mask,
++                              unsigned sads[]);
++#define aom_masked_sad16x16x4d aom_masked_sad16x16x4d_c
++
++unsigned int aom_masked_sad16x32_c(const uint8_t* src,
++                                   int src_stride,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   const uint8_t* second_pred,
++                                   const uint8_t* msk,
++                                   int msk_stride,
++                                   int invert_mask);
++#define aom_masked_sad16x32 aom_masked_sad16x32_c
++
++void aom_masked_sad16x32x4d_c(const uint8_t* src,
++                              int src_stride,
++                              const uint8_t* ref[],
++                              int ref_stride,
++                              const uint8_t* second_pred,
++                              const uint8_t* msk,
++                              int msk_stride,
++                              int invert_mask,
++                              unsigned sads[]);
++#define aom_masked_sad16x32x4d aom_masked_sad16x32x4d_c
++
++unsigned int aom_masked_sad16x8_c(const uint8_t* src,
++                                  int src_stride,
++                                  const uint8_t* ref,
++                                  int ref_stride,
++                                  const uint8_t* second_pred,
++                                  const uint8_t* msk,
++                                  int msk_stride,
++                                  int invert_mask);
++#define aom_masked_sad16x8 aom_masked_sad16x8_c
++
++void aom_masked_sad16x8x4d_c(const uint8_t* src,
++                             int src_stride,
++                             const uint8_t* ref[],
++                             int ref_stride,
++                             const uint8_t* second_pred,
++                             const uint8_t* msk,
++                             int msk_stride,
++                             int invert_mask,
++                             unsigned sads[]);
++#define aom_masked_sad16x8x4d aom_masked_sad16x8x4d_c
++
++unsigned int aom_masked_sad32x16_c(const uint8_t* src,
++                                   int src_stride,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   const uint8_t* second_pred,
++                                   const uint8_t* msk,
++                                   int msk_stride,
++                                   int invert_mask);
++#define aom_masked_sad32x16 aom_masked_sad32x16_c
++
++void aom_masked_sad32x16x4d_c(const uint8_t* src,
++                              int src_stride,
++                              const uint8_t* ref[],
++                              int ref_stride,
++                              const uint8_t* second_pred,
++                              const uint8_t* msk,
++                              int msk_stride,
++                              int invert_mask,
++                              unsigned sads[]);
++#define aom_masked_sad32x16x4d aom_masked_sad32x16x4d_c
++
++unsigned int aom_masked_sad32x32_c(const uint8_t* src,
++                                   int src_stride,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   const uint8_t* second_pred,
++                                   const uint8_t* msk,
++                                   int msk_stride,
++                                   int invert_mask);
++#define aom_masked_sad32x32 aom_masked_sad32x32_c
++
++void aom_masked_sad32x32x4d_c(const uint8_t* src,
++                              int src_stride,
++                              const uint8_t* ref[],
++                              int ref_stride,
++                              const uint8_t* second_pred,
++                              const uint8_t* msk,
++                              int msk_stride,
++                              int invert_mask,
++                              unsigned sads[]);
++#define aom_masked_sad32x32x4d aom_masked_sad32x32x4d_c
++
++unsigned int aom_masked_sad32x64_c(const uint8_t* src,
++                                   int src_stride,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   const uint8_t* second_pred,
++                                   const uint8_t* msk,
++                                   int msk_stride,
++                                   int invert_mask);
++#define aom_masked_sad32x64 aom_masked_sad32x64_c
++
++void aom_masked_sad32x64x4d_c(const uint8_t* src,
++                              int src_stride,
++                              const uint8_t* ref[],
++                              int ref_stride,
++                              const uint8_t* second_pred,
++                              const uint8_t* msk,
++                              int msk_stride,
++                              int invert_mask,
++                              unsigned sads[]);
++#define aom_masked_sad32x64x4d aom_masked_sad32x64x4d_c
++
++unsigned int aom_masked_sad4x4_c(const uint8_t* src,
++                                 int src_stride,
++                                 const uint8_t* ref,
++                                 int ref_stride,
++                                 const uint8_t* second_pred,
++                                 const uint8_t* msk,
++                                 int msk_stride,
++                                 int invert_mask);
++#define aom_masked_sad4x4 aom_masked_sad4x4_c
++
++void aom_masked_sad4x4x4d_c(const uint8_t* src,
++                            int src_stride,
++                            const uint8_t* ref[],
++                            int ref_stride,
++                            const uint8_t* second_pred,
++                            const uint8_t* msk,
++                            int msk_stride,
++                            int invert_mask,
++                            unsigned sads[]);
++#define aom_masked_sad4x4x4d aom_masked_sad4x4x4d_c
++
++unsigned int aom_masked_sad4x8_c(const uint8_t* src,
++                                 int src_stride,
++                                 const uint8_t* ref,
++                                 int ref_stride,
++                                 const uint8_t* second_pred,
++                                 const uint8_t* msk,
++                                 int msk_stride,
++                                 int invert_mask);
++#define aom_masked_sad4x8 aom_masked_sad4x8_c
++
++void aom_masked_sad4x8x4d_c(const uint8_t* src,
++                            int src_stride,
++                            const uint8_t* ref[],
++                            int ref_stride,
++                            const uint8_t* second_pred,
++                            const uint8_t* msk,
++                            int msk_stride,
++                            int invert_mask,
++                            unsigned sads[]);
++#define aom_masked_sad4x8x4d aom_masked_sad4x8x4d_c
++
++unsigned int aom_masked_sad64x128_c(const uint8_t* src,
++                                    int src_stride,
++                                    const uint8_t* ref,
++                                    int ref_stride,
++                                    const uint8_t* second_pred,
++                                    const uint8_t* msk,
++                                    int msk_stride,
++                                    int invert_mask);
++#define aom_masked_sad64x128 aom_masked_sad64x128_c
++
++void aom_masked_sad64x128x4d_c(const uint8_t* src,
++                               int src_stride,
++                               const uint8_t* ref[],
++                               int ref_stride,
++                               const uint8_t* second_pred,
++                               const uint8_t* msk,
++                               int msk_stride,
++                               int invert_mask,
++                               unsigned sads[]);
++#define aom_masked_sad64x128x4d aom_masked_sad64x128x4d_c
++
++unsigned int aom_masked_sad64x32_c(const uint8_t* src,
++                                   int src_stride,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   const uint8_t* second_pred,
++                                   const uint8_t* msk,
++                                   int msk_stride,
++                                   int invert_mask);
++#define aom_masked_sad64x32 aom_masked_sad64x32_c
++
++void aom_masked_sad64x32x4d_c(const uint8_t* src,
++                              int src_stride,
++                              const uint8_t* ref[],
++                              int ref_stride,
++                              const uint8_t* second_pred,
++                              const uint8_t* msk,
++                              int msk_stride,
++                              int invert_mask,
++                              unsigned sads[]);
++#define aom_masked_sad64x32x4d aom_masked_sad64x32x4d_c
++
++unsigned int aom_masked_sad64x64_c(const uint8_t* src,
++                                   int src_stride,
++                                   const uint8_t* ref,
++                                   int ref_stride,
++                                   const uint8_t* second_pred,
++                                   const uint8_t* msk,
++                                   int msk_stride,
++                                   int invert_mask);
++#define aom_masked_sad64x64 aom_masked_sad64x64_c
++
++void aom_masked_sad64x64x4d_c(const uint8_t* src,
++                              int src_stride,
++                              const uint8_t* ref[],
++                              int ref_stride,
++                              const uint8_t* second_pred,
++                              const uint8_t* msk,
++                              int msk_stride,
++                              int invert_mask,
++                              unsigned sads[]);
++#define aom_masked_sad64x64x4d aom_masked_sad64x64x4d_c
++
++unsigned int aom_masked_sad8x16_c(const uint8_t* src,
++                                  int src_stride,
++                                  const uint8_t* ref,
++                                  int ref_stride,
++                                  const uint8_t* second_pred,
++                                  const uint8_t* msk,
++                                  int msk_stride,
++                                  int invert_mask);
++#define aom_masked_sad8x16 aom_masked_sad8x16_c
++
++void aom_masked_sad8x16x4d_c(const uint8_t* src,
++                             int src_stride,
++                             const uint8_t* ref[],
++                             int ref_stride,
++                             const uint8_t* second_pred,
++                             const uint8_t* msk,
++                             int msk_stride,
++                             int invert_mask,
++                             unsigned sads[]);
++#define aom_masked_sad8x16x4d aom_masked_sad8x16x4d_c
++
++unsigned int aom_masked_sad8x4_c(const uint8_t* src,
++                                 int src_stride,
++                                 const uint8_t* ref,
++                                 int ref_stride,
++                                 const uint8_t* second_pred,
++                                 const uint8_t* msk,
++                                 int msk_stride,
++                                 int invert_mask);
++#define aom_masked_sad8x4 aom_masked_sad8x4_c
++
++void aom_masked_sad8x4x4d_c(const uint8_t* src,
++                            int src_stride,
++                            const uint8_t* ref[],
++                            int ref_stride,
++                            const uint8_t* second_pred,
++                            const uint8_t* msk,
++                            int msk_stride,
++                            int invert_mask,
++                            unsigned sads[]);
++#define aom_masked_sad8x4x4d aom_masked_sad8x4x4d_c
++
++unsigned int aom_masked_sad8x8_c(const uint8_t* src,
++                                 int src_stride,
++                                 const uint8_t* ref,
++                                 int ref_stride,
++                                 const uint8_t* second_pred,
++                                 const uint8_t* msk,
++                                 int msk_stride,
++                                 int invert_mask);
++#define aom_masked_sad8x8 aom_masked_sad8x8_c
++
++void aom_masked_sad8x8x4d_c(const uint8_t* src,
++                            int src_stride,
++                            const uint8_t* ref[],
++                            int ref_stride,
++                            const uint8_t* second_pred,
++                            const uint8_t* msk,
++                            int msk_stride,
++                            int invert_mask,
++                            unsigned sads[]);
++#define aom_masked_sad8x8x4d aom_masked_sad8x8x4d_c
++
++unsigned int aom_masked_sub_pixel_variance128x128_c(const uint8_t* src,
++                                                    int src_stride,
++                                                    int xoffset,
++                                                    int yoffset,
++                                                    const uint8_t* ref,
++                                                    int ref_stride,
++                                                    const uint8_t* second_pred,
++                                                    const uint8_t* msk,
++                                                    int msk_stride,
++                                                    int invert_mask,
++                                                    unsigned int* sse);
++#define aom_masked_sub_pixel_variance128x128 \
++  aom_masked_sub_pixel_variance128x128_c
++
++unsigned int aom_masked_sub_pixel_variance128x64_c(const uint8_t* src,
++                                                   int src_stride,
++                                                   int xoffset,
++                                                   int yoffset,
++                                                   const uint8_t* ref,
++                                                   int ref_stride,
++                                                   const uint8_t* second_pred,
++                                                   const uint8_t* msk,
++                                                   int msk_stride,
++                                                   int invert_mask,
++                                                   unsigned int* sse);
++#define aom_masked_sub_pixel_variance128x64 \
++  aom_masked_sub_pixel_variance128x64_c
++
++unsigned int aom_masked_sub_pixel_variance16x16_c(const uint8_t* src,
++                                                  int src_stride,
++                                                  int xoffset,
++                                                  int yoffset,
++                                                  const uint8_t* ref,
++                                                  int ref_stride,
++                                                  const uint8_t* second_pred,
++                                                  const uint8_t* msk,
++                                                  int msk_stride,
++                                                  int invert_mask,
++                                                  unsigned int* sse);
++#define aom_masked_sub_pixel_variance16x16 aom_masked_sub_pixel_variance16x16_c
++
++unsigned int aom_masked_sub_pixel_variance16x32_c(const uint8_t* src,
++                                                  int src_stride,
++                                                  int xoffset,
++                                                  int yoffset,
++                                                  const uint8_t* ref,
++                                                  int ref_stride,
++                                                  const uint8_t* second_pred,
++                                                  const uint8_t* msk,
++                                                  int msk_stride,
++                                                  int invert_mask,
++                                                  unsigned int* sse);
++#define aom_masked_sub_pixel_variance16x32 aom_masked_sub_pixel_variance16x32_c
++
++unsigned int aom_masked_sub_pixel_variance16x8_c(const uint8_t* src,
++                                                 int src_stride,
++                                                 int xoffset,
++                                                 int yoffset,
++                                                 const uint8_t* ref,
++                                                 int ref_stride,
++                                                 const uint8_t* second_pred,
++                                                 const uint8_t* msk,
++                                                 int msk_stride,
++                                                 int invert_mask,
++                                                 unsigned int* sse);
++#define aom_masked_sub_pixel_variance16x8 aom_masked_sub_pixel_variance16x8_c
++
++unsigned int aom_masked_sub_pixel_variance32x16_c(const uint8_t* src,
++                                                  int src_stride,
++                                                  int xoffset,
++                                                  int yoffset,
++                                                  const uint8_t* ref,
++                                                  int ref_stride,
++                                                  const uint8_t* second_pred,
++                                                  const uint8_t* msk,
++                                                  int msk_stride,
++                                                  int invert_mask,
++                                                  unsigned int* sse);
++#define aom_masked_sub_pixel_variance32x16 aom_masked_sub_pixel_variance32x16_c
++
++unsigned int aom_masked_sub_pixel_variance32x32_c(const uint8_t* src,
++                                                  int src_stride,
++                                                  int xoffset,
++                                                  int yoffset,
++                                                  const uint8_t* ref,
++                                                  int ref_stride,
++                                                  const uint8_t* second_pred,
++                                                  const uint8_t* msk,
++                                                  int msk_stride,
++                                                  int invert_mask,
++                                                  unsigned int* sse);
++#define aom_masked_sub_pixel_variance32x32 aom_masked_sub_pixel_variance32x32_c
++
++unsigned int aom_masked_sub_pixel_variance32x64_c(const uint8_t* src,
++                                                  int src_stride,
++                                                  int xoffset,
++                                                  int yoffset,
++                                                  const uint8_t* ref,
++                                                  int ref_stride,
++                                                  const uint8_t* second_pred,
++                                                  const uint8_t* msk,
++                                                  int msk_stride,
++                                                  int invert_mask,
++                                                  unsigned int* sse);
++#define aom_masked_sub_pixel_variance32x64 aom_masked_sub_pixel_variance32x64_c
++
++unsigned int aom_masked_sub_pixel_variance4x4_c(const uint8_t* src,
++                                                int src_stride,
++                                                int xoffset,
++                                                int yoffset,
++                                                const uint8_t* ref,
++                                                int ref_stride,
++                                                const uint8_t* second_pred,
++                                                const uint8_t* msk,
++                                                int msk_stride,
++                                                int invert_mask,
++                                                unsigned int* sse);
++#define aom_masked_sub_pixel_variance4x4 aom_masked_sub_pixel_variance4x4_c
++
++unsigned int aom_masked_sub_pixel_variance4x8_c(const uint8_t* src,
++                                                int src_stride,
++                                                int xoffset,
++                                                int yoffset,
++                                                const uint8_t* ref,
++                                                int ref_stride,
++                                                const uint8_t* second_pred,
++                                                const uint8_t* msk,
++                                                int msk_stride,
++                                                int invert_mask,
++                                                unsigned int* sse);
++#define aom_masked_sub_pixel_variance4x8 aom_masked_sub_pixel_variance4x8_c
++
++unsigned int aom_masked_sub_pixel_variance64x128_c(const uint8_t* src,
++                                                   int src_stride,
++                                                   int xoffset,
++                                                   int yoffset,
++                                                   const uint8_t* ref,
++                                                   int ref_stride,
++                                                   const uint8_t* second_pred,
++                                                   const uint8_t* msk,
++                                                   int msk_stride,
++                                                   int invert_mask,
++                                                   unsigned int* sse);
++#define aom_masked_sub_pixel_variance64x128 \
++  aom_masked_sub_pixel_variance64x128_c
++
++unsigned int aom_masked_sub_pixel_variance64x32_c(const uint8_t* src,
++                                                  int src_stride,
++                                                  int xoffset,
++                                                  int yoffset,
++                                                  const uint8_t* ref,
++                                                  int ref_stride,
++                                                  const uint8_t* second_pred,
++                                                  const uint8_t* msk,
++                                                  int msk_stride,
++                                                  int invert_mask,
++                                                  unsigned int* sse);
++#define aom_masked_sub_pixel_variance64x32 aom_masked_sub_pixel_variance64x32_c
++
++unsigned int aom_masked_sub_pixel_variance64x64_c(const uint8_t* src,
++                                                  int src_stride,
++                                                  int xoffset,
++                                                  int yoffset,
++                                                  const uint8_t* ref,
++                                                  int ref_stride,
++                                                  const uint8_t* second_pred,
++                                                  const uint8_t* msk,
++                                                  int msk_stride,
++                                                  int invert_mask,
++                                                  unsigned int* sse);
++#define aom_masked_sub_pixel_variance64x64 aom_masked_sub_pixel_variance64x64_c
++
++unsigned int aom_masked_sub_pixel_variance8x16_c(const uint8_t* src,
++                                                 int src_stride,
++                                                 int xoffset,
++                                                 int yoffset,
++                                                 const uint8_t* ref,
++                                                 int ref_stride,
++                                                 const uint8_t* second_pred,
++                                                 const uint8_t* msk,
++                                                 int msk_stride,
++                                                 int invert_mask,
++                                                 unsigned int* sse);
++#define aom_masked_sub_pixel_variance8x16 aom_masked_sub_pixel_variance8x16_c
++
++unsigned int aom_masked_sub_pixel_variance8x4_c(const uint8_t* src,
++                                                int src_stride,
++                                                int xoffset,
++                                                int yoffset,
++                                                const uint8_t* ref,
++                                                int ref_stride,
++                                                const uint8_t* second_pred,
++                                                const uint8_t* msk,
++                                                int msk_stride,
++                                                int invert_mask,
++                                                unsigned int* sse);
++#define aom_masked_sub_pixel_variance8x4 aom_masked_sub_pixel_variance8x4_c
++
++unsigned int aom_masked_sub_pixel_variance8x8_c(const uint8_t* src,
++                                                int src_stride,
++                                                int xoffset,
++                                                int yoffset,
++                                                const uint8_t* ref,
++                                                int ref_stride,
++                                                const uint8_t* second_pred,
++                                                const uint8_t* msk,
++                                                int msk_stride,
++                                                int invert_mask,
++                                                unsigned int* sse);
++#define aom_masked_sub_pixel_variance8x8 aom_masked_sub_pixel_variance8x8_c
++
++void aom_minmax_8x8_c(const uint8_t* s,
++                      int p,
++                      const uint8_t* d,
++                      int dp,
++                      int* min,
++                      int* max);
++#define aom_minmax_8x8 aom_minmax_8x8_c
++
++unsigned int aom_mse16x16_c(const uint8_t* src_ptr,
++                            int source_stride,
++                            const uint8_t* ref_ptr,
++                            int recon_stride,
++                            unsigned int* sse);
++#define aom_mse16x16 aom_mse16x16_c
++
++unsigned int aom_mse16x8_c(const uint8_t* src_ptr,
++                           int source_stride,
++                           const uint8_t* ref_ptr,
++                           int recon_stride,
++                           unsigned int* sse);
++#define aom_mse16x8 aom_mse16x8_c
++
++unsigned int aom_mse8x16_c(const uint8_t* src_ptr,
++                           int source_stride,
++                           const uint8_t* ref_ptr,
++                           int recon_stride,
++                           unsigned int* sse);
++#define aom_mse8x16 aom_mse8x16_c
++
++unsigned int aom_mse8x8_c(const uint8_t* src_ptr,
++                          int source_stride,
++                          const uint8_t* ref_ptr,
++                          int recon_stride,
++                          unsigned int* sse);
++#define aom_mse8x8 aom_mse8x8_c
++
++uint64_t aom_mse_wxh_16bit_c(uint8_t* dst,
++                             int dstride,
++                             uint16_t* src,
++                             int sstride,
++                             int w,
++                             int h);
++#define aom_mse_wxh_16bit aom_mse_wxh_16bit_c
++
 +void aom_paeth_predictor_16x16_c(uint8_t* dst,
 +                                 ptrdiff_t y_stride,
 +                                 const uint8_t* above,
@@ -2736,18 +2048,6 @@ index 0000000000..1969860e30
 +                                 const uint8_t* above,
 +                                 const uint8_t* left);
 +#define aom_paeth_predictor_16x32 aom_paeth_predictor_16x32_c
-+
-+void aom_paeth_predictor_16x4_c(uint8_t* dst,
-+                                ptrdiff_t y_stride,
-+                                const uint8_t* above,
-+                                const uint8_t* left);
-+#define aom_paeth_predictor_16x4 aom_paeth_predictor_16x4_c
-+
-+void aom_paeth_predictor_16x64_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_paeth_predictor_16x64 aom_paeth_predictor_16x64_c
 +
 +void aom_paeth_predictor_16x8_c(uint8_t* dst,
 +                                ptrdiff_t y_stride,
@@ -2779,18 +2079,6 @@ index 0000000000..1969860e30
 +                                 const uint8_t* left);
 +#define aom_paeth_predictor_32x64 aom_paeth_predictor_32x64_c
 +
-+void aom_paeth_predictor_32x8_c(uint8_t* dst,
-+                                ptrdiff_t y_stride,
-+                                const uint8_t* above,
-+                                const uint8_t* left);
-+#define aom_paeth_predictor_32x8 aom_paeth_predictor_32x8_c
-+
-+void aom_paeth_predictor_4x16_c(uint8_t* dst,
-+                                ptrdiff_t y_stride,
-+                                const uint8_t* above,
-+                                const uint8_t* left);
-+#define aom_paeth_predictor_4x16 aom_paeth_predictor_4x16_c
-+
 +void aom_paeth_predictor_4x4_c(uint8_t* dst,
 +                               ptrdiff_t y_stride,
 +                               const uint8_t* above,
@@ -2802,12 +2090,6 @@ index 0000000000..1969860e30
 +                               const uint8_t* above,
 +                               const uint8_t* left);
 +#define aom_paeth_predictor_4x8 aom_paeth_predictor_4x8_c
-+
-+void aom_paeth_predictor_64x16_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_paeth_predictor_64x16 aom_paeth_predictor_64x16_c
 +
 +void aom_paeth_predictor_64x32_c(uint8_t* dst,
 +                                 ptrdiff_t y_stride,
@@ -2827,12 +2109,6 @@ index 0000000000..1969860e30
 +                                const uint8_t* left);
 +#define aom_paeth_predictor_8x16 aom_paeth_predictor_8x16_c
 +
-+void aom_paeth_predictor_8x32_c(uint8_t* dst,
-+                                ptrdiff_t y_stride,
-+                                const uint8_t* above,
-+                                const uint8_t* left);
-+#define aom_paeth_predictor_8x32 aom_paeth_predictor_8x32_c
-+
 +void aom_paeth_predictor_8x4_c(uint8_t* dst,
 +                               ptrdiff_t y_stride,
 +                               const uint8_t* above,
@@ -2845,6 +2121,813 @@ index 0000000000..1969860e30
 +                               const uint8_t* left);
 +#define aom_paeth_predictor_8x8 aom_paeth_predictor_8x8_c
 +
++void aom_quantize_b_c(const tran_low_t* coeff_ptr,
++                      intptr_t n_coeffs,
++                      const int16_t* zbin_ptr,
++                      const int16_t* round_ptr,
++                      const int16_t* quant_ptr,
++                      const int16_t* quant_shift_ptr,
++                      tran_low_t* qcoeff_ptr,
++                      tran_low_t* dqcoeff_ptr,
++                      const int16_t* dequant_ptr,
++                      uint16_t* eob_ptr,
++                      const int16_t* scan,
++                      const int16_t* iscan);
++#define aom_quantize_b aom_quantize_b_c
++
++void aom_quantize_b_32x32_c(const tran_low_t* coeff_ptr,
++                            intptr_t n_coeffs,
++                            const int16_t* zbin_ptr,
++                            const int16_t* round_ptr,
++                            const int16_t* quant_ptr,
++                            const int16_t* quant_shift_ptr,
++                            tran_low_t* qcoeff_ptr,
++                            tran_low_t* dqcoeff_ptr,
++                            const int16_t* dequant_ptr,
++                            uint16_t* eob_ptr,
++                            const int16_t* scan,
++                            const int16_t* iscan);
++#define aom_quantize_b_32x32 aom_quantize_b_32x32_c
++
++void aom_quantize_b_32x32_adaptive_c(const tran_low_t* coeff_ptr,
++                                     intptr_t n_coeffs,
++                                     const int16_t* zbin_ptr,
++                                     const int16_t* round_ptr,
++                                     const int16_t* quant_ptr,
++                                     const int16_t* quant_shift_ptr,
++                                     tran_low_t* qcoeff_ptr,
++                                     tran_low_t* dqcoeff_ptr,
++                                     const int16_t* dequant_ptr,
++                                     uint16_t* eob_ptr,
++                                     const int16_t* scan,
++                                     const int16_t* iscan);
++#define aom_quantize_b_32x32_adaptive aom_quantize_b_32x32_adaptive_c
++
++void aom_quantize_b_64x64_c(const tran_low_t* coeff_ptr,
++                            intptr_t n_coeffs,
++                            const int16_t* zbin_ptr,
++                            const int16_t* round_ptr,
++                            const int16_t* quant_ptr,
++                            const int16_t* quant_shift_ptr,
++                            tran_low_t* qcoeff_ptr,
++                            tran_low_t* dqcoeff_ptr,
++                            const int16_t* dequant_ptr,
++                            uint16_t* eob_ptr,
++                            const int16_t* scan,
++                            const int16_t* iscan);
++#define aom_quantize_b_64x64 aom_quantize_b_64x64_c
++
++void aom_quantize_b_64x64_adaptive_c(const tran_low_t* coeff_ptr,
++                                     intptr_t n_coeffs,
++                                     const int16_t* zbin_ptr,
++                                     const int16_t* round_ptr,
++                                     const int16_t* quant_ptr,
++                                     const int16_t* quant_shift_ptr,
++                                     tran_low_t* qcoeff_ptr,
++                                     tran_low_t* dqcoeff_ptr,
++                                     const int16_t* dequant_ptr,
++                                     uint16_t* eob_ptr,
++                                     const int16_t* scan,
++                                     const int16_t* iscan);
++#define aom_quantize_b_64x64_adaptive aom_quantize_b_64x64_adaptive_c
++
++void aom_quantize_b_adaptive_c(const tran_low_t* coeff_ptr,
++                               intptr_t n_coeffs,
++                               const int16_t* zbin_ptr,
++                               const int16_t* round_ptr,
++                               const int16_t* quant_ptr,
++                               const int16_t* quant_shift_ptr,
++                               tran_low_t* qcoeff_ptr,
++                               tran_low_t* dqcoeff_ptr,
++                               const int16_t* dequant_ptr,
++                               uint16_t* eob_ptr,
++                               const int16_t* scan,
++                               const int16_t* iscan);
++#define aom_quantize_b_adaptive aom_quantize_b_adaptive_c
++
++unsigned int aom_sad128x128_c(const uint8_t* src_ptr,
++                              int src_stride,
++                              const uint8_t* ref_ptr,
++                              int ref_stride);
++#define aom_sad128x128 aom_sad128x128_c
++
++unsigned int aom_sad128x128_avg_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride,
++                                  const uint8_t* second_pred);
++#define aom_sad128x128_avg aom_sad128x128_avg_c
++
++void aom_sad128x128x4d_c(const uint8_t* src_ptr,
++                         int src_stride,
++                         const uint8_t* const ref_ptr[],
++                         int ref_stride,
++                         uint32_t* sad_array);
++#define aom_sad128x128x4d aom_sad128x128x4d_c
++
++void aom_sad128x128x4d_avg_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             const uint8_t* second_pred,
++                             uint32_t* sad_array);
++#define aom_sad128x128x4d_avg aom_sad128x128x4d_avg_c
++
++unsigned int aom_sad128x64_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* ref_ptr,
++                             int ref_stride);
++#define aom_sad128x64 aom_sad128x64_c
++
++unsigned int aom_sad128x64_avg_c(const uint8_t* src_ptr,
++                                 int src_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 const uint8_t* second_pred);
++#define aom_sad128x64_avg aom_sad128x64_avg_c
++
++void aom_sad128x64x4d_c(const uint8_t* src_ptr,
++                        int src_stride,
++                        const uint8_t* const ref_ptr[],
++                        int ref_stride,
++                        uint32_t* sad_array);
++#define aom_sad128x64x4d aom_sad128x64x4d_c
++
++void aom_sad128x64x4d_avg_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* const ref_ptr[],
++                            int ref_stride,
++                            const uint8_t* second_pred,
++                            uint32_t* sad_array);
++#define aom_sad128x64x4d_avg aom_sad128x64x4d_avg_c
++
++unsigned int aom_sad128xh_c(const uint8_t* a,
++                            int a_stride,
++                            const uint8_t* b,
++                            int b_stride,
++                            int width,
++                            int height);
++#define aom_sad128xh aom_sad128xh_c
++
++unsigned int aom_sad16x16_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* ref_ptr,
++                            int ref_stride);
++#define aom_sad16x16 aom_sad16x16_c
++
++unsigned int aom_sad16x16_avg_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                const uint8_t* second_pred);
++#define aom_sad16x16_avg aom_sad16x16_avg_c
++
++void aom_sad16x16x4d_c(const uint8_t* src_ptr,
++                       int src_stride,
++                       const uint8_t* const ref_ptr[],
++                       int ref_stride,
++                       uint32_t* sad_array);
++#define aom_sad16x16x4d aom_sad16x16x4d_c
++
++void aom_sad16x16x4d_avg_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           const uint8_t* second_pred,
++                           uint32_t* sad_array);
++#define aom_sad16x16x4d_avg aom_sad16x16x4d_avg_c
++
++unsigned int aom_sad16x32_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* ref_ptr,
++                            int ref_stride);
++#define aom_sad16x32 aom_sad16x32_c
++
++unsigned int aom_sad16x32_avg_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                const uint8_t* second_pred);
++#define aom_sad16x32_avg aom_sad16x32_avg_c
++
++void aom_sad16x32x4d_c(const uint8_t* src_ptr,
++                       int src_stride,
++                       const uint8_t* const ref_ptr[],
++                       int ref_stride,
++                       uint32_t* sad_array);
++#define aom_sad16x32x4d aom_sad16x32x4d_c
++
++void aom_sad16x32x4d_avg_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           const uint8_t* second_pred,
++                           uint32_t* sad_array);
++#define aom_sad16x32x4d_avg aom_sad16x32x4d_avg_c
++
++unsigned int aom_sad16x8_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* ref_ptr,
++                           int ref_stride);
++#define aom_sad16x8 aom_sad16x8_c
++
++unsigned int aom_sad16x8_avg_c(const uint8_t* src_ptr,
++                               int src_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               const uint8_t* second_pred);
++#define aom_sad16x8_avg aom_sad16x8_avg_c
++
++void aom_sad16x8x4d_c(const uint8_t* src_ptr,
++                      int src_stride,
++                      const uint8_t* const ref_ptr[],
++                      int ref_stride,
++                      uint32_t* sad_array);
++#define aom_sad16x8x4d aom_sad16x8x4d_c
++
++void aom_sad16x8x4d_avg_c(const uint8_t* src_ptr,
++                          int src_stride,
++                          const uint8_t* const ref_ptr[],
++                          int ref_stride,
++                          const uint8_t* second_pred,
++                          uint32_t* sad_array);
++#define aom_sad16x8x4d_avg aom_sad16x8x4d_avg_c
++
++unsigned int aom_sad16xh_c(const uint8_t* a,
++                           int a_stride,
++                           const uint8_t* b,
++                           int b_stride,
++                           int width,
++                           int height);
++#define aom_sad16xh aom_sad16xh_c
++
++unsigned int aom_sad32x16_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* ref_ptr,
++                            int ref_stride);
++#define aom_sad32x16 aom_sad32x16_c
++
++unsigned int aom_sad32x16_avg_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                const uint8_t* second_pred);
++#define aom_sad32x16_avg aom_sad32x16_avg_c
++
++void aom_sad32x16x4d_c(const uint8_t* src_ptr,
++                       int src_stride,
++                       const uint8_t* const ref_ptr[],
++                       int ref_stride,
++                       uint32_t* sad_array);
++#define aom_sad32x16x4d aom_sad32x16x4d_c
++
++void aom_sad32x16x4d_avg_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           const uint8_t* second_pred,
++                           uint32_t* sad_array);
++#define aom_sad32x16x4d_avg aom_sad32x16x4d_avg_c
++
++unsigned int aom_sad32x32_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* ref_ptr,
++                            int ref_stride);
++#define aom_sad32x32 aom_sad32x32_c
++
++unsigned int aom_sad32x32_avg_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                const uint8_t* second_pred);
++#define aom_sad32x32_avg aom_sad32x32_avg_c
++
++void aom_sad32x32x4d_c(const uint8_t* src_ptr,
++                       int src_stride,
++                       const uint8_t* const ref_ptr[],
++                       int ref_stride,
++                       uint32_t* sad_array);
++#define aom_sad32x32x4d aom_sad32x32x4d_c
++
++void aom_sad32x32x4d_avg_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           const uint8_t* second_pred,
++                           uint32_t* sad_array);
++#define aom_sad32x32x4d_avg aom_sad32x32x4d_avg_c
++
++unsigned int aom_sad32x64_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* ref_ptr,
++                            int ref_stride);
++#define aom_sad32x64 aom_sad32x64_c
++
++unsigned int aom_sad32x64_avg_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                const uint8_t* second_pred);
++#define aom_sad32x64_avg aom_sad32x64_avg_c
++
++void aom_sad32x64x4d_c(const uint8_t* src_ptr,
++                       int src_stride,
++                       const uint8_t* const ref_ptr[],
++                       int ref_stride,
++                       uint32_t* sad_array);
++#define aom_sad32x64x4d aom_sad32x64x4d_c
++
++void aom_sad32x64x4d_avg_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           const uint8_t* second_pred,
++                           uint32_t* sad_array);
++#define aom_sad32x64x4d_avg aom_sad32x64x4d_avg_c
++
++unsigned int aom_sad32xh_c(const uint8_t* a,
++                           int a_stride,
++                           const uint8_t* b,
++                           int b_stride,
++                           int width,
++                           int height);
++#define aom_sad32xh aom_sad32xh_c
++
++unsigned int aom_sad4x4_c(const uint8_t* src_ptr,
++                          int src_stride,
++                          const uint8_t* ref_ptr,
++                          int ref_stride);
++#define aom_sad4x4 aom_sad4x4_c
++
++unsigned int aom_sad4x4_avg_c(const uint8_t* src_ptr,
++                              int src_stride,
++                              const uint8_t* ref_ptr,
++                              int ref_stride,
++                              const uint8_t* second_pred);
++#define aom_sad4x4_avg aom_sad4x4_avg_c
++
++void aom_sad4x4x4d_c(const uint8_t* src_ptr,
++                     int src_stride,
++                     const uint8_t* const ref_ptr[],
++                     int ref_stride,
++                     uint32_t* sad_array);
++#define aom_sad4x4x4d aom_sad4x4x4d_c
++
++void aom_sad4x4x4d_avg_c(const uint8_t* src_ptr,
++                         int src_stride,
++                         const uint8_t* const ref_ptr[],
++                         int ref_stride,
++                         const uint8_t* second_pred,
++                         uint32_t* sad_array);
++#define aom_sad4x4x4d_avg aom_sad4x4x4d_avg_c
++
++unsigned int aom_sad4x8_c(const uint8_t* src_ptr,
++                          int src_stride,
++                          const uint8_t* ref_ptr,
++                          int ref_stride);
++#define aom_sad4x8 aom_sad4x8_c
++
++unsigned int aom_sad4x8_avg_c(const uint8_t* src_ptr,
++                              int src_stride,
++                              const uint8_t* ref_ptr,
++                              int ref_stride,
++                              const uint8_t* second_pred);
++#define aom_sad4x8_avg aom_sad4x8_avg_c
++
++void aom_sad4x8x4d_c(const uint8_t* src_ptr,
++                     int src_stride,
++                     const uint8_t* const ref_ptr[],
++                     int ref_stride,
++                     uint32_t* sad_array);
++#define aom_sad4x8x4d aom_sad4x8x4d_c
++
++void aom_sad4x8x4d_avg_c(const uint8_t* src_ptr,
++                         int src_stride,
++                         const uint8_t* const ref_ptr[],
++                         int ref_stride,
++                         const uint8_t* second_pred,
++                         uint32_t* sad_array);
++#define aom_sad4x8x4d_avg aom_sad4x8x4d_avg_c
++
++unsigned int aom_sad4xh_c(const uint8_t* a,
++                          int a_stride,
++                          const uint8_t* b,
++                          int b_stride,
++                          int width,
++                          int height);
++#define aom_sad4xh aom_sad4xh_c
++
++unsigned int aom_sad64x128_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* ref_ptr,
++                             int ref_stride);
++#define aom_sad64x128 aom_sad64x128_c
++
++unsigned int aom_sad64x128_avg_c(const uint8_t* src_ptr,
++                                 int src_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 const uint8_t* second_pred);
++#define aom_sad64x128_avg aom_sad64x128_avg_c
++
++void aom_sad64x128x4d_c(const uint8_t* src_ptr,
++                        int src_stride,
++                        const uint8_t* const ref_ptr[],
++                        int ref_stride,
++                        uint32_t* sad_array);
++#define aom_sad64x128x4d aom_sad64x128x4d_c
++
++void aom_sad64x128x4d_avg_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* const ref_ptr[],
++                            int ref_stride,
++                            const uint8_t* second_pred,
++                            uint32_t* sad_array);
++#define aom_sad64x128x4d_avg aom_sad64x128x4d_avg_c
++
++unsigned int aom_sad64x32_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* ref_ptr,
++                            int ref_stride);
++#define aom_sad64x32 aom_sad64x32_c
++
++unsigned int aom_sad64x32_avg_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                const uint8_t* second_pred);
++#define aom_sad64x32_avg aom_sad64x32_avg_c
++
++void aom_sad64x32x4d_c(const uint8_t* src_ptr,
++                       int src_stride,
++                       const uint8_t* const ref_ptr[],
++                       int ref_stride,
++                       uint32_t* sad_array);
++#define aom_sad64x32x4d aom_sad64x32x4d_c
++
++void aom_sad64x32x4d_avg_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           const uint8_t* second_pred,
++                           uint32_t* sad_array);
++#define aom_sad64x32x4d_avg aom_sad64x32x4d_avg_c
++
++unsigned int aom_sad64x64_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* ref_ptr,
++                            int ref_stride);
++#define aom_sad64x64 aom_sad64x64_c
++
++unsigned int aom_sad64x64_avg_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                const uint8_t* second_pred);
++#define aom_sad64x64_avg aom_sad64x64_avg_c
++
++void aom_sad64x64x4d_c(const uint8_t* src_ptr,
++                       int src_stride,
++                       const uint8_t* const ref_ptr[],
++                       int ref_stride,
++                       uint32_t* sad_array);
++#define aom_sad64x64x4d aom_sad64x64x4d_c
++
++void aom_sad64x64x4d_avg_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           const uint8_t* second_pred,
++                           uint32_t* sad_array);
++#define aom_sad64x64x4d_avg aom_sad64x64x4d_avg_c
++
++unsigned int aom_sad64xh_c(const uint8_t* a,
++                           int a_stride,
++                           const uint8_t* b,
++                           int b_stride,
++                           int width,
++                           int height);
++#define aom_sad64xh aom_sad64xh_c
++
++unsigned int aom_sad8x16_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* ref_ptr,
++                           int ref_stride);
++#define aom_sad8x16 aom_sad8x16_c
++
++unsigned int aom_sad8x16_avg_c(const uint8_t* src_ptr,
++                               int src_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               const uint8_t* second_pred);
++#define aom_sad8x16_avg aom_sad8x16_avg_c
++
++void aom_sad8x16x4d_c(const uint8_t* src_ptr,
++                      int src_stride,
++                      const uint8_t* const ref_ptr[],
++                      int ref_stride,
++                      uint32_t* sad_array);
++#define aom_sad8x16x4d aom_sad8x16x4d_c
++
++void aom_sad8x16x4d_avg_c(const uint8_t* src_ptr,
++                          int src_stride,
++                          const uint8_t* const ref_ptr[],
++                          int ref_stride,
++                          const uint8_t* second_pred,
++                          uint32_t* sad_array);
++#define aom_sad8x16x4d_avg aom_sad8x16x4d_avg_c
++
++unsigned int aom_sad8x4_c(const uint8_t* src_ptr,
++                          int src_stride,
++                          const uint8_t* ref_ptr,
++                          int ref_stride);
++#define aom_sad8x4 aom_sad8x4_c
++
++unsigned int aom_sad8x4_avg_c(const uint8_t* src_ptr,
++                              int src_stride,
++                              const uint8_t* ref_ptr,
++                              int ref_stride,
++                              const uint8_t* second_pred);
++#define aom_sad8x4_avg aom_sad8x4_avg_c
++
++void aom_sad8x4x4d_c(const uint8_t* src_ptr,
++                     int src_stride,
++                     const uint8_t* const ref_ptr[],
++                     int ref_stride,
++                     uint32_t* sad_array);
++#define aom_sad8x4x4d aom_sad8x4x4d_c
++
++void aom_sad8x4x4d_avg_c(const uint8_t* src_ptr,
++                         int src_stride,
++                         const uint8_t* const ref_ptr[],
++                         int ref_stride,
++                         const uint8_t* second_pred,
++                         uint32_t* sad_array);
++#define aom_sad8x4x4d_avg aom_sad8x4x4d_avg_c
++
++unsigned int aom_sad8x8_c(const uint8_t* src_ptr,
++                          int src_stride,
++                          const uint8_t* ref_ptr,
++                          int ref_stride);
++#define aom_sad8x8 aom_sad8x8_c
++
++unsigned int aom_sad8x8_avg_c(const uint8_t* src_ptr,
++                              int src_stride,
++                              const uint8_t* ref_ptr,
++                              int ref_stride,
++                              const uint8_t* second_pred);
++#define aom_sad8x8_avg aom_sad8x8_avg_c
++
++void aom_sad8x8x4d_c(const uint8_t* src_ptr,
++                     int src_stride,
++                     const uint8_t* const ref_ptr[],
++                     int ref_stride,
++                     uint32_t* sad_array);
++#define aom_sad8x8x4d aom_sad8x8x4d_c
++
++void aom_sad8x8x4d_avg_c(const uint8_t* src_ptr,
++                         int src_stride,
++                         const uint8_t* const ref_ptr[],
++                         int ref_stride,
++                         const uint8_t* second_pred,
++                         uint32_t* sad_array);
++#define aom_sad8x8x4d_avg aom_sad8x8x4d_avg_c
++
++unsigned int aom_sad8xh_c(const uint8_t* a,
++                          int a_stride,
++                          const uint8_t* b,
++                          int b_stride,
++                          int width,
++                          int height);
++#define aom_sad8xh aom_sad8xh_c
++
++unsigned int aom_sad_skip_128x128_c(const uint8_t* src_ptr,
++                                    int src_stride,
++                                    const uint8_t* ref_ptr,
++                                    int ref_stride);
++#define aom_sad_skip_128x128 aom_sad_skip_128x128_c
++
++void aom_sad_skip_128x128x4d_c(const uint8_t* src_ptr,
++                               int src_stride,
++                               const uint8_t* const ref_ptr[],
++                               int ref_stride,
++                               uint32_t* sad_array);
++#define aom_sad_skip_128x128x4d aom_sad_skip_128x128x4d_c
++
++unsigned int aom_sad_skip_128x64_c(const uint8_t* src_ptr,
++                                   int src_stride,
++                                   const uint8_t* ref_ptr,
++                                   int ref_stride);
++#define aom_sad_skip_128x64 aom_sad_skip_128x64_c
++
++void aom_sad_skip_128x64x4d_c(const uint8_t* src_ptr,
++                              int src_stride,
++                              const uint8_t* const ref_ptr[],
++                              int ref_stride,
++                              uint32_t* sad_array);
++#define aom_sad_skip_128x64x4d aom_sad_skip_128x64x4d_c
++
++unsigned int aom_sad_skip_16x16_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride);
++#define aom_sad_skip_16x16 aom_sad_skip_16x16_c
++
++void aom_sad_skip_16x16x4d_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             uint32_t* sad_array);
++#define aom_sad_skip_16x16x4d aom_sad_skip_16x16x4d_c
++
++unsigned int aom_sad_skip_16x32_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride);
++#define aom_sad_skip_16x32 aom_sad_skip_16x32_c
++
++void aom_sad_skip_16x32x4d_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             uint32_t* sad_array);
++#define aom_sad_skip_16x32x4d aom_sad_skip_16x32x4d_c
++
++unsigned int aom_sad_skip_16x8_c(const uint8_t* src_ptr,
++                                 int src_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride);
++#define aom_sad_skip_16x8 aom_sad_skip_16x8_c
++
++void aom_sad_skip_16x8x4d_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* const ref_ptr[],
++                            int ref_stride,
++                            uint32_t* sad_array);
++#define aom_sad_skip_16x8x4d aom_sad_skip_16x8x4d_c
++
++unsigned int aom_sad_skip_32x16_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride);
++#define aom_sad_skip_32x16 aom_sad_skip_32x16_c
++
++void aom_sad_skip_32x16x4d_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             uint32_t* sad_array);
++#define aom_sad_skip_32x16x4d aom_sad_skip_32x16x4d_c
++
++unsigned int aom_sad_skip_32x32_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride);
++#define aom_sad_skip_32x32 aom_sad_skip_32x32_c
++
++void aom_sad_skip_32x32x4d_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             uint32_t* sad_array);
++#define aom_sad_skip_32x32x4d aom_sad_skip_32x32x4d_c
++
++unsigned int aom_sad_skip_32x64_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride);
++#define aom_sad_skip_32x64 aom_sad_skip_32x64_c
++
++void aom_sad_skip_32x64x4d_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             uint32_t* sad_array);
++#define aom_sad_skip_32x64x4d aom_sad_skip_32x64x4d_c
++
++unsigned int aom_sad_skip_4x4_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride);
++#define aom_sad_skip_4x4 aom_sad_skip_4x4_c
++
++void aom_sad_skip_4x4x4d_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           uint32_t* sad_array);
++#define aom_sad_skip_4x4x4d aom_sad_skip_4x4x4d_c
++
++unsigned int aom_sad_skip_4x8_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride);
++#define aom_sad_skip_4x8 aom_sad_skip_4x8_c
++
++void aom_sad_skip_4x8x4d_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           uint32_t* sad_array);
++#define aom_sad_skip_4x8x4d aom_sad_skip_4x8x4d_c
++
++unsigned int aom_sad_skip_64x128_c(const uint8_t* src_ptr,
++                                   int src_stride,
++                                   const uint8_t* ref_ptr,
++                                   int ref_stride);
++#define aom_sad_skip_64x128 aom_sad_skip_64x128_c
++
++void aom_sad_skip_64x128x4d_c(const uint8_t* src_ptr,
++                              int src_stride,
++                              const uint8_t* const ref_ptr[],
++                              int ref_stride,
++                              uint32_t* sad_array);
++#define aom_sad_skip_64x128x4d aom_sad_skip_64x128x4d_c
++
++unsigned int aom_sad_skip_64x32_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride);
++#define aom_sad_skip_64x32 aom_sad_skip_64x32_c
++
++void aom_sad_skip_64x32x4d_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             uint32_t* sad_array);
++#define aom_sad_skip_64x32x4d aom_sad_skip_64x32x4d_c
++
++unsigned int aom_sad_skip_64x64_c(const uint8_t* src_ptr,
++                                  int src_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride);
++#define aom_sad_skip_64x64 aom_sad_skip_64x64_c
++
++void aom_sad_skip_64x64x4d_c(const uint8_t* src_ptr,
++                             int src_stride,
++                             const uint8_t* const ref_ptr[],
++                             int ref_stride,
++                             uint32_t* sad_array);
++#define aom_sad_skip_64x64x4d aom_sad_skip_64x64x4d_c
++
++unsigned int aom_sad_skip_8x16_c(const uint8_t* src_ptr,
++                                 int src_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride);
++#define aom_sad_skip_8x16 aom_sad_skip_8x16_c
++
++void aom_sad_skip_8x16x4d_c(const uint8_t* src_ptr,
++                            int src_stride,
++                            const uint8_t* const ref_ptr[],
++                            int ref_stride,
++                            uint32_t* sad_array);
++#define aom_sad_skip_8x16x4d aom_sad_skip_8x16x4d_c
++
++unsigned int aom_sad_skip_8x4_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride);
++#define aom_sad_skip_8x4 aom_sad_skip_8x4_c
++
++void aom_sad_skip_8x4x4d_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           uint32_t* sad_array);
++#define aom_sad_skip_8x4x4d aom_sad_skip_8x4x4d_c
++
++unsigned int aom_sad_skip_8x8_c(const uint8_t* src_ptr,
++                                int src_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride);
++#define aom_sad_skip_8x8 aom_sad_skip_8x8_c
++
++void aom_sad_skip_8x8x4d_c(const uint8_t* src_ptr,
++                           int src_stride,
++                           const uint8_t* const ref_ptr[],
++                           int ref_stride,
++                           uint32_t* sad_array);
++#define aom_sad_skip_8x8x4d aom_sad_skip_8x8x4d_c
++
++int aom_satd_c(const tran_low_t* coeff, int length);
++#define aom_satd aom_satd_c
++
++int aom_satd_lp_c(const int16_t* coeff, int length);
++#define aom_satd_lp aom_satd_lp_c
++
++void aom_scaled_2d_c(const uint8_t* src,
++                     ptrdiff_t src_stride,
++                     uint8_t* dst,
++                     ptrdiff_t dst_stride,
++                     const InterpKernel* filter,
++                     int x0_q4,
++                     int x_step_q4,
++                     int y0_q4,
++                     int y_step_q4,
++                     int w,
++                     int h);
++#define aom_scaled_2d aom_scaled_2d_c
++
 +void aom_smooth_h_predictor_16x16_c(uint8_t* dst,
 +                                    ptrdiff_t y_stride,
 +                                    const uint8_t* above,
@@ -2856,18 +2939,6 @@ index 0000000000..1969860e30
 +                                    const uint8_t* above,
 +                                    const uint8_t* left);
 +#define aom_smooth_h_predictor_16x32 aom_smooth_h_predictor_16x32_c
-+
-+void aom_smooth_h_predictor_16x4_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_h_predictor_16x4 aom_smooth_h_predictor_16x4_c
-+
-+void aom_smooth_h_predictor_16x64_c(uint8_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint8_t* above,
-+                                    const uint8_t* left);
-+#define aom_smooth_h_predictor_16x64 aom_smooth_h_predictor_16x64_c
 +
 +void aom_smooth_h_predictor_16x8_c(uint8_t* dst,
 +                                   ptrdiff_t y_stride,
@@ -2899,18 +2970,6 @@ index 0000000000..1969860e30
 +                                    const uint8_t* left);
 +#define aom_smooth_h_predictor_32x64 aom_smooth_h_predictor_32x64_c
 +
-+void aom_smooth_h_predictor_32x8_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_h_predictor_32x8 aom_smooth_h_predictor_32x8_c
-+
-+void aom_smooth_h_predictor_4x16_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_h_predictor_4x16 aom_smooth_h_predictor_4x16_c
-+
 +void aom_smooth_h_predictor_4x4_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
 +                                  const uint8_t* above,
@@ -2922,12 +2981,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* above,
 +                                  const uint8_t* left);
 +#define aom_smooth_h_predictor_4x8 aom_smooth_h_predictor_4x8_c
-+
-+void aom_smooth_h_predictor_64x16_c(uint8_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint8_t* above,
-+                                    const uint8_t* left);
-+#define aom_smooth_h_predictor_64x16 aom_smooth_h_predictor_64x16_c
 +
 +void aom_smooth_h_predictor_64x32_c(uint8_t* dst,
 +                                    ptrdiff_t y_stride,
@@ -2946,12 +2999,6 @@ index 0000000000..1969860e30
 +                                   const uint8_t* above,
 +                                   const uint8_t* left);
 +#define aom_smooth_h_predictor_8x16 aom_smooth_h_predictor_8x16_c
-+
-+void aom_smooth_h_predictor_8x32_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_h_predictor_8x32 aom_smooth_h_predictor_8x32_c
 +
 +void aom_smooth_h_predictor_8x4_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
@@ -2976,18 +3023,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* above,
 +                                  const uint8_t* left);
 +#define aom_smooth_predictor_16x32 aom_smooth_predictor_16x32_c
-+
-+void aom_smooth_predictor_16x4_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_smooth_predictor_16x4 aom_smooth_predictor_16x4_c
-+
-+void aom_smooth_predictor_16x64_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_smooth_predictor_16x64 aom_smooth_predictor_16x64_c
 +
 +void aom_smooth_predictor_16x8_c(uint8_t* dst,
 +                                 ptrdiff_t y_stride,
@@ -3019,18 +3054,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* left);
 +#define aom_smooth_predictor_32x64 aom_smooth_predictor_32x64_c
 +
-+void aom_smooth_predictor_32x8_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_smooth_predictor_32x8 aom_smooth_predictor_32x8_c
-+
-+void aom_smooth_predictor_4x16_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_smooth_predictor_4x16 aom_smooth_predictor_4x16_c
-+
 +void aom_smooth_predictor_4x4_c(uint8_t* dst,
 +                                ptrdiff_t y_stride,
 +                                const uint8_t* above,
@@ -3042,12 +3065,6 @@ index 0000000000..1969860e30
 +                                const uint8_t* above,
 +                                const uint8_t* left);
 +#define aom_smooth_predictor_4x8 aom_smooth_predictor_4x8_c
-+
-+void aom_smooth_predictor_64x16_c(uint8_t* dst,
-+                                  ptrdiff_t y_stride,
-+                                  const uint8_t* above,
-+                                  const uint8_t* left);
-+#define aom_smooth_predictor_64x16 aom_smooth_predictor_64x16_c
 +
 +void aom_smooth_predictor_64x32_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
@@ -3066,12 +3083,6 @@ index 0000000000..1969860e30
 +                                 const uint8_t* above,
 +                                 const uint8_t* left);
 +#define aom_smooth_predictor_8x16 aom_smooth_predictor_8x16_c
-+
-+void aom_smooth_predictor_8x32_c(uint8_t* dst,
-+                                 ptrdiff_t y_stride,
-+                                 const uint8_t* above,
-+                                 const uint8_t* left);
-+#define aom_smooth_predictor_8x32 aom_smooth_predictor_8x32_c
 +
 +void aom_smooth_predictor_8x4_c(uint8_t* dst,
 +                                ptrdiff_t y_stride,
@@ -3096,18 +3107,6 @@ index 0000000000..1969860e30
 +                                    const uint8_t* above,
 +                                    const uint8_t* left);
 +#define aom_smooth_v_predictor_16x32 aom_smooth_v_predictor_16x32_c
-+
-+void aom_smooth_v_predictor_16x4_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_v_predictor_16x4 aom_smooth_v_predictor_16x4_c
-+
-+void aom_smooth_v_predictor_16x64_c(uint8_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint8_t* above,
-+                                    const uint8_t* left);
-+#define aom_smooth_v_predictor_16x64 aom_smooth_v_predictor_16x64_c
 +
 +void aom_smooth_v_predictor_16x8_c(uint8_t* dst,
 +                                   ptrdiff_t y_stride,
@@ -3139,18 +3138,6 @@ index 0000000000..1969860e30
 +                                    const uint8_t* left);
 +#define aom_smooth_v_predictor_32x64 aom_smooth_v_predictor_32x64_c
 +
-+void aom_smooth_v_predictor_32x8_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_v_predictor_32x8 aom_smooth_v_predictor_32x8_c
-+
-+void aom_smooth_v_predictor_4x16_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_v_predictor_4x16 aom_smooth_v_predictor_4x16_c
-+
 +void aom_smooth_v_predictor_4x4_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
 +                                  const uint8_t* above,
@@ -3162,12 +3149,6 @@ index 0000000000..1969860e30
 +                                  const uint8_t* above,
 +                                  const uint8_t* left);
 +#define aom_smooth_v_predictor_4x8 aom_smooth_v_predictor_4x8_c
-+
-+void aom_smooth_v_predictor_64x16_c(uint8_t* dst,
-+                                    ptrdiff_t y_stride,
-+                                    const uint8_t* above,
-+                                    const uint8_t* left);
-+#define aom_smooth_v_predictor_64x16 aom_smooth_v_predictor_64x16_c
 +
 +void aom_smooth_v_predictor_64x32_c(uint8_t* dst,
 +                                    ptrdiff_t y_stride,
@@ -3187,12 +3168,6 @@ index 0000000000..1969860e30
 +                                   const uint8_t* left);
 +#define aom_smooth_v_predictor_8x16 aom_smooth_v_predictor_8x16_c
 +
-+void aom_smooth_v_predictor_8x32_c(uint8_t* dst,
-+                                   ptrdiff_t y_stride,
-+                                   const uint8_t* above,
-+                                   const uint8_t* left);
-+#define aom_smooth_v_predictor_8x32 aom_smooth_v_predictor_8x32_c
-+
 +void aom_smooth_v_predictor_8x4_c(uint8_t* dst,
 +                                  ptrdiff_t y_stride,
 +                                  const uint8_t* above,
@@ -3205,6 +3180,370 @@ index 0000000000..1969860e30
 +                                  const uint8_t* left);
 +#define aom_smooth_v_predictor_8x8 aom_smooth_v_predictor_8x8_c
 +
++int64_t aom_sse_c(const uint8_t* a,
++                  int a_stride,
++                  const uint8_t* b,
++                  int b_stride,
++                  int width,
++                  int height);
++#define aom_sse aom_sse_c
++
++void aom_ssim_parms_8x8_c(const uint8_t* s,
++                          int sp,
++                          const uint8_t* r,
++                          int rp,
++                          uint32_t* sum_s,
++                          uint32_t* sum_r,
++                          uint32_t* sum_sq_s,
++                          uint32_t* sum_sq_r,
++                          uint32_t* sum_sxr);
++#define aom_ssim_parms_8x8 aom_ssim_parms_8x8_c
++
++uint32_t aom_sub_pixel_avg_variance128x128_c(const uint8_t* src_ptr,
++                                             int source_stride,
++                                             int xoffset,
++                                             int yoffset,
++                                             const uint8_t* ref_ptr,
++                                             int ref_stride,
++                                             uint32_t* sse,
++                                             const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance128x128 aom_sub_pixel_avg_variance128x128_c
++
++uint32_t aom_sub_pixel_avg_variance128x64_c(const uint8_t* src_ptr,
++                                            int source_stride,
++                                            int xoffset,
++                                            int yoffset,
++                                            const uint8_t* ref_ptr,
++                                            int ref_stride,
++                                            uint32_t* sse,
++                                            const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance128x64 aom_sub_pixel_avg_variance128x64_c
++
++uint32_t aom_sub_pixel_avg_variance16x16_c(const uint8_t* src_ptr,
++                                           int source_stride,
++                                           int xoffset,
++                                           int yoffset,
++                                           const uint8_t* ref_ptr,
++                                           int ref_stride,
++                                           uint32_t* sse,
++                                           const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance16x16 aom_sub_pixel_avg_variance16x16_c
++
++uint32_t aom_sub_pixel_avg_variance16x32_c(const uint8_t* src_ptr,
++                                           int source_stride,
++                                           int xoffset,
++                                           int yoffset,
++                                           const uint8_t* ref_ptr,
++                                           int ref_stride,
++                                           uint32_t* sse,
++                                           const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance16x32 aom_sub_pixel_avg_variance16x32_c
++
++uint32_t aom_sub_pixel_avg_variance16x8_c(const uint8_t* src_ptr,
++                                          int source_stride,
++                                          int xoffset,
++                                          int yoffset,
++                                          const uint8_t* ref_ptr,
++                                          int ref_stride,
++                                          uint32_t* sse,
++                                          const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance16x8 aom_sub_pixel_avg_variance16x8_c
++
++uint32_t aom_sub_pixel_avg_variance32x16_c(const uint8_t* src_ptr,
++                                           int source_stride,
++                                           int xoffset,
++                                           int yoffset,
++                                           const uint8_t* ref_ptr,
++                                           int ref_stride,
++                                           uint32_t* sse,
++                                           const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance32x16 aom_sub_pixel_avg_variance32x16_c
++
++uint32_t aom_sub_pixel_avg_variance32x32_c(const uint8_t* src_ptr,
++                                           int source_stride,
++                                           int xoffset,
++                                           int yoffset,
++                                           const uint8_t* ref_ptr,
++                                           int ref_stride,
++                                           uint32_t* sse,
++                                           const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance32x32 aom_sub_pixel_avg_variance32x32_c
++
++uint32_t aom_sub_pixel_avg_variance32x64_c(const uint8_t* src_ptr,
++                                           int source_stride,
++                                           int xoffset,
++                                           int yoffset,
++                                           const uint8_t* ref_ptr,
++                                           int ref_stride,
++                                           uint32_t* sse,
++                                           const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance32x64 aom_sub_pixel_avg_variance32x64_c
++
++uint32_t aom_sub_pixel_avg_variance4x4_c(const uint8_t* src_ptr,
++                                         int source_stride,
++                                         int xoffset,
++                                         int yoffset,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         uint32_t* sse,
++                                         const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance4x4 aom_sub_pixel_avg_variance4x4_c
++
++uint32_t aom_sub_pixel_avg_variance4x8_c(const uint8_t* src_ptr,
++                                         int source_stride,
++                                         int xoffset,
++                                         int yoffset,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         uint32_t* sse,
++                                         const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance4x8 aom_sub_pixel_avg_variance4x8_c
++
++uint32_t aom_sub_pixel_avg_variance64x128_c(const uint8_t* src_ptr,
++                                            int source_stride,
++                                            int xoffset,
++                                            int yoffset,
++                                            const uint8_t* ref_ptr,
++                                            int ref_stride,
++                                            uint32_t* sse,
++                                            const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance64x128 aom_sub_pixel_avg_variance64x128_c
++
++uint32_t aom_sub_pixel_avg_variance64x32_c(const uint8_t* src_ptr,
++                                           int source_stride,
++                                           int xoffset,
++                                           int yoffset,
++                                           const uint8_t* ref_ptr,
++                                           int ref_stride,
++                                           uint32_t* sse,
++                                           const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance64x32 aom_sub_pixel_avg_variance64x32_c
++
++uint32_t aom_sub_pixel_avg_variance64x64_c(const uint8_t* src_ptr,
++                                           int source_stride,
++                                           int xoffset,
++                                           int yoffset,
++                                           const uint8_t* ref_ptr,
++                                           int ref_stride,
++                                           uint32_t* sse,
++                                           const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance64x64 aom_sub_pixel_avg_variance64x64_c
++
++uint32_t aom_sub_pixel_avg_variance8x16_c(const uint8_t* src_ptr,
++                                          int source_stride,
++                                          int xoffset,
++                                          int yoffset,
++                                          const uint8_t* ref_ptr,
++                                          int ref_stride,
++                                          uint32_t* sse,
++                                          const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance8x16 aom_sub_pixel_avg_variance8x16_c
++
++uint32_t aom_sub_pixel_avg_variance8x4_c(const uint8_t* src_ptr,
++                                         int source_stride,
++                                         int xoffset,
++                                         int yoffset,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         uint32_t* sse,
++                                         const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance8x4 aom_sub_pixel_avg_variance8x4_c
++
++uint32_t aom_sub_pixel_avg_variance8x8_c(const uint8_t* src_ptr,
++                                         int source_stride,
++                                         int xoffset,
++                                         int yoffset,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         uint32_t* sse,
++                                         const uint8_t* second_pred);
++#define aom_sub_pixel_avg_variance8x8 aom_sub_pixel_avg_variance8x8_c
++
++uint32_t aom_sub_pixel_variance128x128_c(const uint8_t* src_ptr,
++                                         int source_stride,
++                                         int xoffset,
++                                         int yoffset,
++                                         const uint8_t* ref_ptr,
++                                         int ref_stride,
++                                         uint32_t* sse);
++#define aom_sub_pixel_variance128x128 aom_sub_pixel_variance128x128_c
++
++uint32_t aom_sub_pixel_variance128x64_c(const uint8_t* src_ptr,
++                                        int source_stride,
++                                        int xoffset,
++                                        int yoffset,
++                                        const uint8_t* ref_ptr,
++                                        int ref_stride,
++                                        uint32_t* sse);
++#define aom_sub_pixel_variance128x64 aom_sub_pixel_variance128x64_c
++
++uint32_t aom_sub_pixel_variance16x16_c(const uint8_t* src_ptr,
++                                       int source_stride,
++                                       int xoffset,
++                                       int yoffset,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       uint32_t* sse);
++#define aom_sub_pixel_variance16x16 aom_sub_pixel_variance16x16_c
++
++uint32_t aom_sub_pixel_variance16x32_c(const uint8_t* src_ptr,
++                                       int source_stride,
++                                       int xoffset,
++                                       int yoffset,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       uint32_t* sse);
++#define aom_sub_pixel_variance16x32 aom_sub_pixel_variance16x32_c
++
++uint32_t aom_sub_pixel_variance16x8_c(const uint8_t* src_ptr,
++                                      int source_stride,
++                                      int xoffset,
++                                      int yoffset,
++                                      const uint8_t* ref_ptr,
++                                      int ref_stride,
++                                      uint32_t* sse);
++#define aom_sub_pixel_variance16x8 aom_sub_pixel_variance16x8_c
++
++uint32_t aom_sub_pixel_variance32x16_c(const uint8_t* src_ptr,
++                                       int source_stride,
++                                       int xoffset,
++                                       int yoffset,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       uint32_t* sse);
++#define aom_sub_pixel_variance32x16 aom_sub_pixel_variance32x16_c
++
++uint32_t aom_sub_pixel_variance32x32_c(const uint8_t* src_ptr,
++                                       int source_stride,
++                                       int xoffset,
++                                       int yoffset,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       uint32_t* sse);
++#define aom_sub_pixel_variance32x32 aom_sub_pixel_variance32x32_c
++
++uint32_t aom_sub_pixel_variance32x64_c(const uint8_t* src_ptr,
++                                       int source_stride,
++                                       int xoffset,
++                                       int yoffset,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       uint32_t* sse);
++#define aom_sub_pixel_variance32x64 aom_sub_pixel_variance32x64_c
++
++uint32_t aom_sub_pixel_variance4x4_c(const uint8_t* src_ptr,
++                                     int source_stride,
++                                     int xoffset,
++                                     int yoffset,
++                                     const uint8_t* ref_ptr,
++                                     int ref_stride,
++                                     uint32_t* sse);
++#define aom_sub_pixel_variance4x4 aom_sub_pixel_variance4x4_c
++
++uint32_t aom_sub_pixel_variance4x8_c(const uint8_t* src_ptr,
++                                     int source_stride,
++                                     int xoffset,
++                                     int yoffset,
++                                     const uint8_t* ref_ptr,
++                                     int ref_stride,
++                                     uint32_t* sse);
++#define aom_sub_pixel_variance4x8 aom_sub_pixel_variance4x8_c
++
++uint32_t aom_sub_pixel_variance64x128_c(const uint8_t* src_ptr,
++                                        int source_stride,
++                                        int xoffset,
++                                        int yoffset,
++                                        const uint8_t* ref_ptr,
++                                        int ref_stride,
++                                        uint32_t* sse);
++#define aom_sub_pixel_variance64x128 aom_sub_pixel_variance64x128_c
++
++uint32_t aom_sub_pixel_variance64x32_c(const uint8_t* src_ptr,
++                                       int source_stride,
++                                       int xoffset,
++                                       int yoffset,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       uint32_t* sse);
++#define aom_sub_pixel_variance64x32 aom_sub_pixel_variance64x32_c
++
++uint32_t aom_sub_pixel_variance64x64_c(const uint8_t* src_ptr,
++                                       int source_stride,
++                                       int xoffset,
++                                       int yoffset,
++                                       const uint8_t* ref_ptr,
++                                       int ref_stride,
++                                       uint32_t* sse);
++#define aom_sub_pixel_variance64x64 aom_sub_pixel_variance64x64_c
++
++uint32_t aom_sub_pixel_variance8x16_c(const uint8_t* src_ptr,
++                                      int source_stride,
++                                      int xoffset,
++                                      int yoffset,
++                                      const uint8_t* ref_ptr,
++                                      int ref_stride,
++                                      uint32_t* sse);
++#define aom_sub_pixel_variance8x16 aom_sub_pixel_variance8x16_c
++
++uint32_t aom_sub_pixel_variance8x4_c(const uint8_t* src_ptr,
++                                     int source_stride,
++                                     int xoffset,
++                                     int yoffset,
++                                     const uint8_t* ref_ptr,
++                                     int ref_stride,
++                                     uint32_t* sse);
++#define aom_sub_pixel_variance8x4 aom_sub_pixel_variance8x4_c
++
++uint32_t aom_sub_pixel_variance8x8_c(const uint8_t* src_ptr,
++                                     int source_stride,
++                                     int xoffset,
++                                     int yoffset,
++                                     const uint8_t* ref_ptr,
++                                     int ref_stride,
++                                     uint32_t* sse);
++#define aom_sub_pixel_variance8x8 aom_sub_pixel_variance8x8_c
++
++void aom_subtract_block_c(int rows,
++                          int cols,
++                          int16_t* diff_ptr,
++                          ptrdiff_t diff_stride,
++                          const uint8_t* src_ptr,
++                          ptrdiff_t src_stride,
++                          const uint8_t* pred_ptr,
++                          ptrdiff_t pred_stride);
++#define aom_subtract_block aom_subtract_block_c
++
++uint64_t aom_sum_squares_2d_i16_c(const int16_t* src,
++                                  int stride,
++                                  int width,
++                                  int height);
++#define aom_sum_squares_2d_i16 aom_sum_squares_2d_i16_c
++
++uint64_t aom_sum_squares_i16_c(const int16_t* src, uint32_t N);
++#define aom_sum_squares_i16 aom_sum_squares_i16_c
++
++uint64_t aom_sum_sse_2d_i16_c(const int16_t* src,
++                              int src_stride,
++                              int width,
++                              int height,
++                              int* sum);
++#define aom_sum_sse_2d_i16 aom_sum_sse_2d_i16_c
++
++void aom_upsampled_pred_c(MACROBLOCKD* xd,
++                          const struct AV1Common* const cm,
++                          int mi_row,
++                          int mi_col,
++                          const MV* const mv,
++                          uint8_t* comp_pred,
++                          int width,
++                          int height,
++                          int subpel_x_q3,
++                          int subpel_y_q3,
++                          const uint8_t* ref,
++                          int ref_stride,
++                          int subpel_search);
++#define aom_upsampled_pred aom_upsampled_pred_c
++
 +void aom_v_predictor_16x16_c(uint8_t* dst,
 +                             ptrdiff_t y_stride,
 +                             const uint8_t* above,
@@ -3216,18 +3555,6 @@ index 0000000000..1969860e30
 +                             const uint8_t* above,
 +                             const uint8_t* left);
 +#define aom_v_predictor_16x32 aom_v_predictor_16x32_c
-+
-+void aom_v_predictor_16x4_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_v_predictor_16x4 aom_v_predictor_16x4_c
-+
-+void aom_v_predictor_16x64_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_v_predictor_16x64 aom_v_predictor_16x64_c
 +
 +void aom_v_predictor_16x8_c(uint8_t* dst,
 +                            ptrdiff_t y_stride,
@@ -3259,18 +3586,6 @@ index 0000000000..1969860e30
 +                             const uint8_t* left);
 +#define aom_v_predictor_32x64 aom_v_predictor_32x64_c
 +
-+void aom_v_predictor_32x8_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_v_predictor_32x8 aom_v_predictor_32x8_c
-+
-+void aom_v_predictor_4x16_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_v_predictor_4x16 aom_v_predictor_4x16_c
-+
 +void aom_v_predictor_4x4_c(uint8_t* dst,
 +                           ptrdiff_t y_stride,
 +                           const uint8_t* above,
@@ -3282,12 +3597,6 @@ index 0000000000..1969860e30
 +                           const uint8_t* above,
 +                           const uint8_t* left);
 +#define aom_v_predictor_4x8 aom_v_predictor_4x8_c
-+
-+void aom_v_predictor_64x16_c(uint8_t* dst,
-+                             ptrdiff_t y_stride,
-+                             const uint8_t* above,
-+                             const uint8_t* left);
-+#define aom_v_predictor_64x16 aom_v_predictor_64x16_c
 +
 +void aom_v_predictor_64x32_c(uint8_t* dst,
 +                             ptrdiff_t y_stride,
@@ -3307,12 +3616,6 @@ index 0000000000..1969860e30
 +                            const uint8_t* left);
 +#define aom_v_predictor_8x16 aom_v_predictor_8x16_c
 +
-+void aom_v_predictor_8x32_c(uint8_t* dst,
-+                            ptrdiff_t y_stride,
-+                            const uint8_t* above,
-+                            const uint8_t* left);
-+#define aom_v_predictor_8x32 aom_v_predictor_8x32_c
-+
 +void aom_v_predictor_8x4_c(uint8_t* dst,
 +                           ptrdiff_t y_stride,
 +                           const uint8_t* above,
@@ -3325,17 +3628,154 @@ index 0000000000..1969860e30
 +                           const uint8_t* left);
 +#define aom_v_predictor_8x8 aom_v_predictor_8x8_c
 +
++uint64_t aom_var_2d_u16_c(uint8_t* src, int src_stride, int width, int height);
++#define aom_var_2d_u16 aom_var_2d_u16_c
++
++uint64_t aom_var_2d_u8_c(uint8_t* src, int src_stride, int width, int height);
++#define aom_var_2d_u8 aom_var_2d_u8_c
++
++unsigned int aom_variance128x128_c(const uint8_t* src_ptr,
++                                   int source_stride,
++                                   const uint8_t* ref_ptr,
++                                   int ref_stride,
++                                   unsigned int* sse);
++#define aom_variance128x128 aom_variance128x128_c
++
++unsigned int aom_variance128x64_c(const uint8_t* src_ptr,
++                                  int source_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride,
++                                  unsigned int* sse);
++#define aom_variance128x64 aom_variance128x64_c
++
++unsigned int aom_variance16x16_c(const uint8_t* src_ptr,
++                                 int source_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 unsigned int* sse);
++#define aom_variance16x16 aom_variance16x16_c
++
++unsigned int aom_variance16x32_c(const uint8_t* src_ptr,
++                                 int source_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 unsigned int* sse);
++#define aom_variance16x32 aom_variance16x32_c
++
++unsigned int aom_variance16x8_c(const uint8_t* src_ptr,
++                                int source_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                unsigned int* sse);
++#define aom_variance16x8 aom_variance16x8_c
++
++unsigned int aom_variance2x2_c(const uint8_t* src_ptr,
++                               int source_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               unsigned int* sse);
++#define aom_variance2x2 aom_variance2x2_c
++
++unsigned int aom_variance2x4_c(const uint8_t* src_ptr,
++                               int source_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               unsigned int* sse);
++#define aom_variance2x4 aom_variance2x4_c
++
++unsigned int aom_variance32x16_c(const uint8_t* src_ptr,
++                                 int source_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 unsigned int* sse);
++#define aom_variance32x16 aom_variance32x16_c
++
++unsigned int aom_variance32x32_c(const uint8_t* src_ptr,
++                                 int source_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 unsigned int* sse);
++#define aom_variance32x32 aom_variance32x32_c
++
++unsigned int aom_variance32x64_c(const uint8_t* src_ptr,
++                                 int source_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 unsigned int* sse);
++#define aom_variance32x64 aom_variance32x64_c
++
++unsigned int aom_variance4x2_c(const uint8_t* src_ptr,
++                               int source_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               unsigned int* sse);
++#define aom_variance4x2 aom_variance4x2_c
++
++unsigned int aom_variance4x4_c(const uint8_t* src_ptr,
++                               int source_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               unsigned int* sse);
++#define aom_variance4x4 aom_variance4x4_c
++
++unsigned int aom_variance4x8_c(const uint8_t* src_ptr,
++                               int source_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               unsigned int* sse);
++#define aom_variance4x8 aom_variance4x8_c
++
++unsigned int aom_variance64x128_c(const uint8_t* src_ptr,
++                                  int source_stride,
++                                  const uint8_t* ref_ptr,
++                                  int ref_stride,
++                                  unsigned int* sse);
++#define aom_variance64x128 aom_variance64x128_c
++
++unsigned int aom_variance64x32_c(const uint8_t* src_ptr,
++                                 int source_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 unsigned int* sse);
++#define aom_variance64x32 aom_variance64x32_c
++
++unsigned int aom_variance64x64_c(const uint8_t* src_ptr,
++                                 int source_stride,
++                                 const uint8_t* ref_ptr,
++                                 int ref_stride,
++                                 unsigned int* sse);
++#define aom_variance64x64 aom_variance64x64_c
++
++unsigned int aom_variance8x16_c(const uint8_t* src_ptr,
++                                int source_stride,
++                                const uint8_t* ref_ptr,
++                                int ref_stride,
++                                unsigned int* sse);
++#define aom_variance8x16 aom_variance8x16_c
++
++unsigned int aom_variance8x4_c(const uint8_t* src_ptr,
++                               int source_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               unsigned int* sse);
++#define aom_variance8x4 aom_variance8x4_c
++
++unsigned int aom_variance8x8_c(const uint8_t* src_ptr,
++                               int source_stride,
++                               const uint8_t* ref_ptr,
++                               int ref_stride,
++                               unsigned int* sse);
++#define aom_variance8x8 aom_variance8x8_c
++
++int aom_vector_var_c(const int16_t* ref, const int16_t* src, const int bwl);
++#define aom_vector_var aom_vector_var_c
++
 +void aom_dsp_rtcd(void);
 +
 +#include "config/aom_config.h"
 +
 +#ifdef RTCD_C
-+#include "aom_ports/ppc.h"
-+static void setup_rtcd_internal(void) {
-+  int flags = ppc_simd_caps();
-+
-+  (void)flags;
-+}
++static void setup_rtcd_internal(void) {}
 +#endif
 +
 +#ifdef __cplusplus
@@ -3497,17 +3937,18 @@ index 0000000000..084b2e062f
 +                               int vstart2);
 +#define aom_yv12_partial_copy_y aom_yv12_partial_copy_y_c
 +
++int aom_yv12_realloc_with_new_border_c(struct yv12_buffer_config* ybf,
++                                       int new_border,
++                                       int byte_alignment,
++                                       int num_planes);
++#define aom_yv12_realloc_with_new_border aom_yv12_realloc_with_new_border_c
++
 +void aom_scale_rtcd(void);
 +
 +#include "config/aom_config.h"
 +
 +#ifdef RTCD_C
-+#include "aom_ports/ppc.h"
-+static void setup_rtcd_internal(void) {
-+  int flags = ppc_simd_caps();
-+
-+  (void)flags;
-+}
++static void setup_rtcd_internal(void) {}
 +#endif
 +
 +#ifdef __cplusplus
@@ -3536,13 +3977,13 @@ index 0000000000..350fb916c1
 + */
 +
 +#include "aom/aom_integer.h"
++#include "aom_dsp/odintrin.h"
 +#include "aom_dsp/txfm_common.h"
 +#include "av1/common/av1_txfm.h"
 +#include "av1/common/common.h"
 +#include "av1/common/convolve.h"
 +#include "av1/common/enums.h"
 +#include "av1/common/filter.h"
-+#include "av1/common/odintrin.h"
 +#include "av1/common/quant_common.h"
 +#include "av1/common/restoration.h"
 +
@@ -3557,14 +3998,42 @@ index 0000000000..350fb916c1
 +struct NN_CONFIG;
 +typedef struct NN_CONFIG NN_CONFIG;
 +
++enum { NONE, RELU, SOFTSIGN, SIGMOID } UENUM1BYTE(ACTIVATION);
++#if CONFIG_NN_V2
++enum { SOFTMAX_CROSS_ENTROPY } UENUM1BYTE(LOSS);
++struct NN_CONFIG_V2;
++typedef struct NN_CONFIG_V2 NN_CONFIG_V2;
++struct FC_LAYER;
++typedef struct FC_LAYER FC_LAYER;
++#endif  // CONFIG_NN_V2
++
++struct CNN_CONFIG;
++typedef struct CNN_CONFIG CNN_CONFIG;
++struct CNN_LAYER_CONFIG;
++typedef struct CNN_LAYER_CONFIG CNN_LAYER_CONFIG;
++struct CNN_THREAD_DATA;
++typedef struct CNN_THREAD_DATA CNN_THREAD_DATA;
++struct CNN_BRANCH_CONFIG;
++typedef struct CNN_BRANCH_CONFIG CNN_BRANCH_CONFIG;
++struct CNN_MULTI_OUT;
++typedef struct CNN_MULTI_OUT CNN_MULTI_OUT;
++
 +/* Function pointers return by CfL functions */
 +typedef void (*cfl_subsample_lbd_fn)(const uint8_t* input,
 +                                     int input_stride,
 +                                     uint16_t* output_q3);
 +
++#if CONFIG_AV1_HIGHBITDEPTH
 +typedef void (*cfl_subsample_hbd_fn)(const uint16_t* input,
 +                                     int input_stride,
 +                                     uint16_t* output_q3);
++
++typedef void (*cfl_predict_hbd_fn)(const int16_t* src,
++                                   uint16_t* dst,
++                                   int dst_stride,
++                                   int alpha_q3,
++                                   int bd);
++#endif
 +
 +typedef void (*cfl_subtract_average_fn)(const uint16_t* src, int16_t* dst);
 +
@@ -3573,28 +4042,37 @@ index 0000000000..350fb916c1
 +                                   int dst_stride,
 +                                   int alpha_q3);
 +
-+typedef void (*cfl_predict_hbd_fn)(const int16_t* src,
-+                                   uint16_t* dst,
-+                                   int dst_stride,
-+                                   int alpha_q3,
-+                                   int bd);
-+
 +#ifdef __cplusplus
 +extern "C" {
 +#endif
 +
-+void apply_selfguided_restoration_c(const uint8_t* dat,
-+                                    int width,
-+                                    int height,
-+                                    int stride,
-+                                    int eps,
-+                                    const int* xqd,
-+                                    uint8_t* dst,
-+                                    int dst_stride,
-+                                    int32_t* tmpbuf,
-+                                    int bit_depth,
-+                                    int highbd);
-+#define apply_selfguided_restoration apply_selfguided_restoration_c
++void aom_quantize_b_helper_c(const tran_low_t* coeff_ptr,
++                             intptr_t n_coeffs,
++                             const int16_t* zbin_ptr,
++                             const int16_t* round_ptr,
++                             const int16_t* quant_ptr,
++                             const int16_t* quant_shift_ptr,
++                             tran_low_t* qcoeff_ptr,
++                             tran_low_t* dqcoeff_ptr,
++                             const int16_t* dequant_ptr,
++                             uint16_t* eob_ptr,
++                             const int16_t* scan,
++                             const int16_t* iscan,
++                             const qm_val_t* qm_ptr,
++                             const qm_val_t* iqm_ptr,
++                             const int log_scale);
++#define aom_quantize_b_helper aom_quantize_b_helper_c
++
++int64_t av1_block_error_c(const tran_low_t* coeff,
++                          const tran_low_t* dqcoeff,
++                          intptr_t block_size,
++                          int64_t* ssz);
++#define av1_block_error av1_block_error_c
++
++int64_t av1_block_error_lp_c(const int16_t* coeff,
++                             const int16_t* dqcoeff,
++                             intptr_t block_size);
++#define av1_block_error_lp av1_block_error_lp_c
 +
 +void av1_build_compound_diffwtd_mask_c(uint8_t* mask,
 +                                       DIFFWTD_MASK_TYPE mask_type,
@@ -3631,18 +4109,29 @@ index 0000000000..350fb916c1
 +#define av1_build_compound_diffwtd_mask_highbd \
 +  av1_build_compound_diffwtd_mask_highbd_c
 +
-+void av1_convolve_2d_copy_sr_c(const uint8_t* src,
-+                               int src_stride,
-+                               uint8_t* dst,
-+                               int dst_stride,
-+                               int w,
-+                               int h,
-+                               const InterpFilterParams* filter_params_x,
-+                               const InterpFilterParams* filter_params_y,
-+                               const int subpel_x_q4,
-+                               const int subpel_y_q4,
-+                               ConvolveParams* conv_params);
-+#define av1_convolve_2d_copy_sr av1_convolve_2d_copy_sr_c
++void av1_calc_indices_dim1_c(const int* data,
++                             const int* centroids,
++                             uint8_t* indices,
++                             int n,
++                             int k);
++#define av1_calc_indices_dim1 av1_calc_indices_dim1_c
++
++void av1_calc_indices_dim2_c(const int* data,
++                             const int* centroids,
++                             uint8_t* indices,
++                             int n,
++                             int k);
++#define av1_calc_indices_dim2 av1_calc_indices_dim2_c
++
++double av1_compute_cross_correlation_c(unsigned char* im1,
++                                       int stride1,
++                                       int x1,
++                                       int y1,
++                                       unsigned char* im2,
++                                       int stride2,
++                                       int x2,
++                                       int y2);
++#define av1_compute_cross_correlation av1_compute_cross_correlation_c
 +
 +void av1_convolve_2d_scale_c(const uint8_t* src,
 +                             int src_stride,
@@ -3654,7 +4143,7 @@ index 0000000000..350fb916c1
 +                             const InterpFilterParams* filter_params_y,
 +                             const int subpel_x_qn,
 +                             const int x_step_qn,
-+                             const int subpel_y_q4,
++                             const int subpel_y_qn,
 +                             const int y_step_qn,
 +                             ConvolveParams* conv_params);
 +#define av1_convolve_2d_scale av1_convolve_2d_scale_c
@@ -3667,8 +4156,8 @@ index 0000000000..350fb916c1
 +                          int h,
 +                          const InterpFilterParams* filter_params_x,
 +                          const InterpFilterParams* filter_params_y,
-+                          const int subpel_x_q4,
-+                          const int subpel_y_q4,
++                          const int subpel_x_qn,
++                          const int subpel_y_qn,
 +                          ConvolveParams* conv_params);
 +#define av1_convolve_2d_sr av1_convolve_2d_sr_c
 +
@@ -3690,9 +4179,7 @@ index 0000000000..350fb916c1
 +                         int w,
 +                         int h,
 +                         const InterpFilterParams* filter_params_x,
-+                         const InterpFilterParams* filter_params_y,
-+                         const int subpel_x_q4,
-+                         const int subpel_y_q4,
++                         const int subpel_x_qn,
 +                         ConvolveParams* conv_params);
 +#define av1_convolve_x_sr av1_convolve_x_sr_c
 +
@@ -3702,12 +4189,20 @@ index 0000000000..350fb916c1
 +                         int dst_stride,
 +                         int w,
 +                         int h,
-+                         const InterpFilterParams* filter_params_x,
 +                         const InterpFilterParams* filter_params_y,
-+                         const int subpel_x_q4,
-+                         const int subpel_y_q4,
-+                         ConvolveParams* conv_params);
++                         const int subpel_y_qn);
 +#define av1_convolve_y_sr av1_convolve_y_sr_c
++
++int av1_denoiser_filter_c(const uint8_t* sig,
++                          int sig_stride,
++                          const uint8_t* mc_avg,
++                          int mc_avg_stride,
++                          uint8_t* avg,
++                          int avg_stride,
++                          int increase_denoising,
++                          BLOCK_SIZE bs,
++                          int motion_magnitude);
++#define av1_denoiser_filter av1_denoiser_filter_c
 +
 +void av1_dist_wtd_convolve_2d_c(const uint8_t* src,
 +                                int src_stride,
@@ -3717,8 +4212,8 @@ index 0000000000..350fb916c1
 +                                int h,
 +                                const InterpFilterParams* filter_params_x,
 +                                const InterpFilterParams* filter_params_y,
-+                                const int subpel_x_q4,
-+                                const int subpel_y_q4,
++                                const int subpel_x_qn,
++                                const int subpel_y_qn,
 +                                ConvolveParams* conv_params);
 +#define av1_dist_wtd_convolve_2d av1_dist_wtd_convolve_2d_c
 +
@@ -3728,10 +4223,6 @@ index 0000000000..350fb916c1
 +                                     int dst_stride,
 +                                     int w,
 +                                     int h,
-+                                     const InterpFilterParams* filter_params_x,
-+                                     const InterpFilterParams* filter_params_y,
-+                                     const int subpel_x_q4,
-+                                     const int subpel_y_q4,
 +                                     ConvolveParams* conv_params);
 +#define av1_dist_wtd_convolve_2d_copy av1_dist_wtd_convolve_2d_copy_c
 +
@@ -3742,9 +4233,7 @@ index 0000000000..350fb916c1
 +                               int w,
 +                               int h,
 +                               const InterpFilterParams* filter_params_x,
-+                               const InterpFilterParams* filter_params_y,
-+                               const int subpel_x_q4,
-+                               const int subpel_y_q4,
++                               const int subpel_x_qn,
 +                               ConvolveParams* conv_params);
 +#define av1_dist_wtd_convolve_x av1_dist_wtd_convolve_x_c
 +
@@ -3754,10 +4243,8 @@ index 0000000000..350fb916c1
 +                               int dst_stride,
 +                               int w,
 +                               int h,
-+                               const InterpFilterParams* filter_params_x,
 +                               const InterpFilterParams* filter_params_y,
-+                               const int subpel_x_q4,
-+                               const int subpel_y_q4,
++                               const int subpel_y_qn,
 +                               ConvolveParams* conv_params);
 +#define av1_dist_wtd_convolve_y av1_dist_wtd_convolve_y_c
 +
@@ -3809,6 +4296,128 @@ index 0000000000..350fb916c1
 +                                  int mode);
 +#define av1_filter_intra_predictor av1_filter_intra_predictor_c
 +
++void av1_fwd_txfm2d_16x16_c(const int16_t* input,
++                            int32_t* output,
++                            int stride,
++                            TX_TYPE tx_type,
++                            int bd);
++#define av1_fwd_txfm2d_16x16 av1_fwd_txfm2d_16x16_c
++
++void av1_fwd_txfm2d_16x32_c(const int16_t* input,
++                            int32_t* output,
++                            int stride,
++                            TX_TYPE tx_type,
++                            int bd);
++#define av1_fwd_txfm2d_16x32 av1_fwd_txfm2d_16x32_c
++
++void av1_fwd_txfm2d_16x4_c(const int16_t* input,
++                           int32_t* output,
++                           int stride,
++                           TX_TYPE tx_type,
++                           int bd);
++#define av1_fwd_txfm2d_16x4 av1_fwd_txfm2d_16x4_c
++
++void av1_fwd_txfm2d_16x8_c(const int16_t* input,
++                           int32_t* output,
++                           int stride,
++                           TX_TYPE tx_type,
++                           int bd);
++#define av1_fwd_txfm2d_16x8 av1_fwd_txfm2d_16x8_c
++
++void av1_fwd_txfm2d_32x16_c(const int16_t* input,
++                            int32_t* output,
++                            int stride,
++                            TX_TYPE tx_type,
++                            int bd);
++#define av1_fwd_txfm2d_32x16 av1_fwd_txfm2d_32x16_c
++
++void av1_fwd_txfm2d_32x32_c(const int16_t* input,
++                            int32_t* output,
++                            int stride,
++                            TX_TYPE tx_type,
++                            int bd);
++#define av1_fwd_txfm2d_32x32 av1_fwd_txfm2d_32x32_c
++
++void av1_fwd_txfm2d_32x64_c(const int16_t* input,
++                            int32_t* output,
++                            int stride,
++                            TX_TYPE tx_type,
++                            int bd);
++#define av1_fwd_txfm2d_32x64 av1_fwd_txfm2d_32x64_c
++
++void av1_fwd_txfm2d_4x4_c(const int16_t* input,
++                          int32_t* output,
++                          int stride,
++                          TX_TYPE tx_type,
++                          int bd);
++#define av1_fwd_txfm2d_4x4 av1_fwd_txfm2d_4x4_c
++
++void av1_fwd_txfm2d_4x8_c(const int16_t* input,
++                          int32_t* output,
++                          int stride,
++                          TX_TYPE tx_type,
++                          int bd);
++#define av1_fwd_txfm2d_4x8 av1_fwd_txfm2d_4x8_c
++
++void av1_fwd_txfm2d_64x32_c(const int16_t* input,
++                            int32_t* output,
++                            int stride,
++                            TX_TYPE tx_type,
++                            int bd);
++#define av1_fwd_txfm2d_64x32 av1_fwd_txfm2d_64x32_c
++
++void av1_fwd_txfm2d_64x64_c(const int16_t* input,
++                            int32_t* output,
++                            int stride,
++                            TX_TYPE tx_type,
++                            int bd);
++#define av1_fwd_txfm2d_64x64 av1_fwd_txfm2d_64x64_c
++
++void av1_fwd_txfm2d_8x16_c(const int16_t* input,
++                           int32_t* output,
++                           int stride,
++                           TX_TYPE tx_type,
++                           int bd);
++#define av1_fwd_txfm2d_8x16 av1_fwd_txfm2d_8x16_c
++
++void av1_fwd_txfm2d_8x4_c(const int16_t* input,
++                          int32_t* output,
++                          int stride,
++                          TX_TYPE tx_type,
++                          int bd);
++#define av1_fwd_txfm2d_8x4 av1_fwd_txfm2d_8x4_c
++
++void av1_fwd_txfm2d_8x8_c(const int16_t* input,
++                          int32_t* output,
++                          int stride,
++                          TX_TYPE tx_type,
++                          int bd);
++#define av1_fwd_txfm2d_8x8 av1_fwd_txfm2d_8x8_c
++
++void av1_fwht4x4_c(const int16_t* input, tran_low_t* output, int stride);
++#define av1_fwht4x4 av1_fwht4x4_c
++
++uint32_t av1_get_crc32c_value_c(void* crc_calculator,
++                                uint8_t* p,
++                                size_t length);
++#define av1_get_crc32c_value av1_get_crc32c_value_c
++
++void av1_get_horver_correlation_full_c(const int16_t* diff,
++                                       int stride,
++                                       int w,
++                                       int h,
++                                       float* hcorr,
++                                       float* vcorr);
++#define av1_get_horver_correlation_full av1_get_horver_correlation_full_c
++
++void av1_get_nz_map_contexts_c(const uint8_t* const levels,
++                               const int16_t* const scan,
++                               const uint16_t eob,
++                               const TX_SIZE tx_size,
++                               const TX_CLASS tx_class,
++                               int8_t* const coeff_contexts);
++#define av1_get_nz_map_contexts av1_get_nz_map_contexts_c
++
 +void av1_highbd_convolve8_c(const uint8_t* src,
 +                            ptrdiff_t src_stride,
 +                            uint8_t* dst,
@@ -3848,50 +4457,6 @@ index 0000000000..350fb916c1
 +                                 int bps);
 +#define av1_highbd_convolve8_vert av1_highbd_convolve8_vert_c
 +
-+void av1_highbd_convolve_2d_copy_sr_c(const uint16_t* src,
-+                                      int src_stride,
-+                                      uint16_t* dst,
-+                                      int dst_stride,
-+                                      int w,
-+                                      int h,
-+                                      const InterpFilterParams* filter_params_x,
-+                                      const InterpFilterParams* filter_params_y,
-+                                      const int subpel_x_q4,
-+                                      const int subpel_y_q4,
-+                                      ConvolveParams* conv_params,
-+                                      int bd);
-+#define av1_highbd_convolve_2d_copy_sr av1_highbd_convolve_2d_copy_sr_c
-+
-+void av1_highbd_convolve_2d_scale_c(const uint16_t* src,
-+                                    int src_stride,
-+                                    uint16_t* dst,
-+                                    int dst_stride,
-+                                    int w,
-+                                    int h,
-+                                    const InterpFilterParams* filter_params_x,
-+                                    const InterpFilterParams* filter_params_y,
-+                                    const int subpel_x_q4,
-+                                    const int x_step_qn,
-+                                    const int subpel_y_q4,
-+                                    const int y_step_qn,
-+                                    ConvolveParams* conv_params,
-+                                    int bd);
-+#define av1_highbd_convolve_2d_scale av1_highbd_convolve_2d_scale_c
-+
-+void av1_highbd_convolve_2d_sr_c(const uint16_t* src,
-+                                 int src_stride,
-+                                 uint16_t* dst,
-+                                 int dst_stride,
-+                                 int w,
-+                                 int h,
-+                                 const InterpFilterParams* filter_params_x,
-+                                 const InterpFilterParams* filter_params_y,
-+                                 const int subpel_x_q4,
-+                                 const int subpel_y_q4,
-+                                 ConvolveParams* conv_params,
-+                                 int bd);
-+#define av1_highbd_convolve_2d_sr av1_highbd_convolve_2d_sr_c
-+
 +void av1_highbd_convolve_avg_c(const uint8_t* src,
 +                               ptrdiff_t src_stride,
 +                               uint8_t* dst,
@@ -3918,180 +4483,119 @@ index 0000000000..350fb916c1
 +                                int bps);
 +#define av1_highbd_convolve_copy av1_highbd_convolve_copy_c
 +
-+void av1_highbd_convolve_horiz_rs_c(const uint16_t* src,
-+                                    int src_stride,
-+                                    uint16_t* dst,
-+                                    int dst_stride,
-+                                    int w,
-+                                    int h,
-+                                    const int16_t* x_filters,
-+                                    int x0_qn,
-+                                    int x_step_qn,
-+                                    int bd);
-+#define av1_highbd_convolve_horiz_rs av1_highbd_convolve_horiz_rs_c
++void av1_highbd_fwht4x4_c(const int16_t* input, tran_low_t* output, int stride);
++#define av1_highbd_fwht4x4 av1_highbd_fwht4x4_c
 +
-+void av1_highbd_convolve_x_sr_c(const uint16_t* src,
-+                                int src_stride,
-+                                uint16_t* dst,
-+                                int dst_stride,
-+                                int w,
-+                                int h,
-+                                const InterpFilterParams* filter_params_x,
-+                                const InterpFilterParams* filter_params_y,
-+                                const int subpel_x_q4,
-+                                const int subpel_y_q4,
-+                                ConvolveParams* conv_params,
-+                                int bd);
-+#define av1_highbd_convolve_x_sr av1_highbd_convolve_x_sr_c
-+
-+void av1_highbd_convolve_y_sr_c(const uint16_t* src,
-+                                int src_stride,
-+                                uint16_t* dst,
-+                                int dst_stride,
-+                                int w,
-+                                int h,
-+                                const InterpFilterParams* filter_params_x,
-+                                const InterpFilterParams* filter_params_y,
-+                                const int subpel_x_q4,
-+                                const int subpel_y_q4,
-+                                ConvolveParams* conv_params,
-+                                int bd);
-+#define av1_highbd_convolve_y_sr av1_highbd_convolve_y_sr_c
-+
-+void av1_highbd_dist_wtd_convolve_2d_c(
-+    const uint16_t* src,
-+    int src_stride,
-+    uint16_t* dst,
-+    int dst_stride,
-+    int w,
-+    int h,
-+    const InterpFilterParams* filter_params_x,
-+    const InterpFilterParams* filter_params_y,
-+    const int subpel_x_q4,
-+    const int subpel_y_q4,
-+    ConvolveParams* conv_params,
-+    int bd);
-+#define av1_highbd_dist_wtd_convolve_2d av1_highbd_dist_wtd_convolve_2d_c
-+
-+void av1_highbd_dist_wtd_convolve_2d_copy_c(
-+    const uint16_t* src,
-+    int src_stride,
-+    uint16_t* dst,
-+    int dst_stride,
-+    int w,
-+    int h,
-+    const InterpFilterParams* filter_params_x,
-+    const InterpFilterParams* filter_params_y,
-+    const int subpel_x_q4,
-+    const int subpel_y_q4,
-+    ConvolveParams* conv_params,
-+    int bd);
-+#define av1_highbd_dist_wtd_convolve_2d_copy \
-+  av1_highbd_dist_wtd_convolve_2d_copy_c
-+
-+void av1_highbd_dist_wtd_convolve_x_c(const uint16_t* src,
-+                                      int src_stride,
-+                                      uint16_t* dst,
-+                                      int dst_stride,
-+                                      int w,
-+                                      int h,
-+                                      const InterpFilterParams* filter_params_x,
-+                                      const InterpFilterParams* filter_params_y,
-+                                      const int subpel_x_q4,
-+                                      const int subpel_y_q4,
-+                                      ConvolveParams* conv_params,
-+                                      int bd);
-+#define av1_highbd_dist_wtd_convolve_x av1_highbd_dist_wtd_convolve_x_c
-+
-+void av1_highbd_dist_wtd_convolve_y_c(const uint16_t* src,
-+                                      int src_stride,
-+                                      uint16_t* dst,
-+                                      int dst_stride,
-+                                      int w,
-+                                      int h,
-+                                      const InterpFilterParams* filter_params_x,
-+                                      const InterpFilterParams* filter_params_y,
-+                                      const int subpel_x_q4,
-+                                      const int subpel_y_q4,
-+                                      ConvolveParams* conv_params,
-+                                      int bd);
-+#define av1_highbd_dist_wtd_convolve_y av1_highbd_dist_wtd_convolve_y_c
-+
-+void av1_highbd_dr_prediction_z1_c(uint16_t* dst,
-+                                   ptrdiff_t stride,
-+                                   int bw,
-+                                   int bh,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int upsample_above,
-+                                   int dx,
-+                                   int dy,
-+                                   int bd);
-+#define av1_highbd_dr_prediction_z1 av1_highbd_dr_prediction_z1_c
-+
-+void av1_highbd_dr_prediction_z2_c(uint16_t* dst,
-+                                   ptrdiff_t stride,
-+                                   int bw,
-+                                   int bh,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int upsample_above,
-+                                   int upsample_left,
-+                                   int dx,
-+                                   int dy,
-+                                   int bd);
-+#define av1_highbd_dr_prediction_z2 av1_highbd_dr_prediction_z2_c
-+
-+void av1_highbd_dr_prediction_z3_c(uint16_t* dst,
-+                                   ptrdiff_t stride,
-+                                   int bw,
-+                                   int bh,
-+                                   const uint16_t* above,
-+                                   const uint16_t* left,
-+                                   int upsample_left,
-+                                   int dx,
-+                                   int dy,
-+                                   int bd);
-+#define av1_highbd_dr_prediction_z3 av1_highbd_dr_prediction_z3_c
-+
-+void av1_highbd_inv_txfm_add_c(const tran_low_t* dqcoeff,
-+                               uint8_t* dst,
++void av1_highbd_inv_txfm_add_c(const tran_low_t* input,
++                               uint8_t* dest,
 +                               int stride,
 +                               const TxfmParam* txfm_param);
 +#define av1_highbd_inv_txfm_add av1_highbd_inv_txfm_add_c
 +
-+void av1_highbd_inv_txfm_add_16x4_c(const tran_low_t* dqcoeff,
-+                                    uint8_t* dst,
++void av1_highbd_inv_txfm_add_16x32_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_16x32 av1_highbd_inv_txfm_add_16x32_c
++
++void av1_highbd_inv_txfm_add_16x4_c(const tran_low_t* input,
++                                    uint8_t* dest,
 +                                    int stride,
 +                                    const TxfmParam* txfm_param);
 +#define av1_highbd_inv_txfm_add_16x4 av1_highbd_inv_txfm_add_16x4_c
 +
-+void av1_highbd_inv_txfm_add_4x16_c(const tran_low_t* dqcoeff,
-+                                    uint8_t* dst,
++void av1_highbd_inv_txfm_add_16x64_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_16x64 av1_highbd_inv_txfm_add_16x64_c
++
++void av1_highbd_inv_txfm_add_16x8_c(const tran_low_t* input,
++                                    uint8_t* dest,
++                                    int stride,
++                                    const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_16x8 av1_highbd_inv_txfm_add_16x8_c
++
++void av1_highbd_inv_txfm_add_32x16_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_32x16 av1_highbd_inv_txfm_add_32x16_c
++
++void av1_highbd_inv_txfm_add_32x32_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_32x32 av1_highbd_inv_txfm_add_32x32_c
++
++void av1_highbd_inv_txfm_add_32x64_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_32x64 av1_highbd_inv_txfm_add_32x64_c
++
++void av1_highbd_inv_txfm_add_32x8_c(const tran_low_t* input,
++                                    uint8_t* dest,
++                                    int stride,
++                                    const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_32x8 av1_highbd_inv_txfm_add_32x8_c
++
++void av1_highbd_inv_txfm_add_4x16_c(const tran_low_t* input,
++                                    uint8_t* dest,
 +                                    int stride,
 +                                    const TxfmParam* txfm_param);
 +#define av1_highbd_inv_txfm_add_4x16 av1_highbd_inv_txfm_add_4x16_c
 +
-+void av1_highbd_inv_txfm_add_4x4_c(const tran_low_t* dqcoeff,
-+                                   uint8_t* dst,
++void av1_highbd_inv_txfm_add_4x4_c(const tran_low_t* input,
++                                   uint8_t* dest,
 +                                   int stride,
 +                                   const TxfmParam* txfm_param);
 +#define av1_highbd_inv_txfm_add_4x4 av1_highbd_inv_txfm_add_4x4_c
 +
-+void av1_highbd_inv_txfm_add_4x8_c(const tran_low_t* dqcoeff,
-+                                   uint8_t* dst,
++void av1_highbd_inv_txfm_add_4x8_c(const tran_low_t* input,
++                                   uint8_t* dest,
 +                                   int stride,
 +                                   const TxfmParam* txfm_param);
 +#define av1_highbd_inv_txfm_add_4x8 av1_highbd_inv_txfm_add_4x8_c
 +
-+void av1_highbd_inv_txfm_add_8x4_c(const tran_low_t* dqcoeff,
-+                                   uint8_t* dst,
++void av1_highbd_inv_txfm_add_64x16_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_64x16 av1_highbd_inv_txfm_add_64x16_c
++
++void av1_highbd_inv_txfm_add_64x32_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_64x32 av1_highbd_inv_txfm_add_64x32_c
++
++void av1_highbd_inv_txfm_add_64x64_c(const tran_low_t* input,
++                                     uint8_t* dest,
++                                     int stride,
++                                     const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_64x64 av1_highbd_inv_txfm_add_64x64_c
++
++void av1_highbd_inv_txfm_add_8x16_c(const tran_low_t* input,
++                                    uint8_t* dest,
++                                    int stride,
++                                    const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_8x16 av1_highbd_inv_txfm_add_8x16_c
++
++void av1_highbd_inv_txfm_add_8x32_c(const tran_low_t* input,
++                                    uint8_t* dest,
++                                    int stride,
++                                    const TxfmParam* txfm_param);
++#define av1_highbd_inv_txfm_add_8x32 av1_highbd_inv_txfm_add_8x32_c
++
++void av1_highbd_inv_txfm_add_8x4_c(const tran_low_t* input,
++                                   uint8_t* dest,
 +                                   int stride,
 +                                   const TxfmParam* txfm_param);
 +#define av1_highbd_inv_txfm_add_8x4 av1_highbd_inv_txfm_add_8x4_c
 +
-+void av1_highbd_inv_txfm_add_8x8_c(const tran_low_t* dqcoeff,
-+                                   uint8_t* dst,
++void av1_highbd_inv_txfm_add_8x8_c(const tran_low_t* input,
++                                   uint8_t* dest,
 +                                   int stride,
 +                                   const TxfmParam* txfm_param);
 +#define av1_highbd_inv_txfm_add_8x8 av1_highbd_inv_txfm_add_8x8_c
@@ -4107,41 +4611,6 @@ index 0000000000..350fb916c1
 +                                int dest_stride,
 +                                int bd);
 +#define av1_highbd_iwht4x4_1_add av1_highbd_iwht4x4_1_add_c
-+
-+void av1_highbd_warp_affine_c(const int32_t* mat,
-+                              const uint16_t* ref,
-+                              int width,
-+                              int height,
-+                              int stride,
-+                              uint16_t* pred,
-+                              int p_col,
-+                              int p_row,
-+                              int p_width,
-+                              int p_height,
-+                              int p_stride,
-+                              int subsampling_x,
-+                              int subsampling_y,
-+                              int bd,
-+                              ConvolveParams* conv_params,
-+                              int16_t alpha,
-+                              int16_t beta,
-+                              int16_t gamma,
-+                              int16_t delta);
-+#define av1_highbd_warp_affine av1_highbd_warp_affine_c
-+
-+void av1_highbd_wiener_convolve_add_src_c(const uint8_t* src,
-+                                          ptrdiff_t src_stride,
-+                                          uint8_t* dst,
-+                                          ptrdiff_t dst_stride,
-+                                          const int16_t* filter_x,
-+                                          int x_step_q4,
-+                                          const int16_t* filter_y,
-+                                          int y_step_q4,
-+                                          int w,
-+                                          int h,
-+                                          const ConvolveParams* conv_params,
-+                                          int bps);
-+#define av1_highbd_wiener_convolve_add_src av1_highbd_wiener_convolve_add_src_c
 +
 +void av1_inv_txfm2d_add_16x16_c(const int32_t* input,
 +                                uint16_t* output,
@@ -4282,20 +4751,106 @@ index 0000000000..350fb916c1
 +                        const TxfmParam* txfm_param);
 +#define av1_inv_txfm_add av1_inv_txfm_add_c
 +
++void av1_lowbd_fwd_txfm_c(const int16_t* src_diff,
++                          tran_low_t* coeff,
++                          int diff_stride,
++                          TxfmParam* txfm_param);
++#define av1_lowbd_fwd_txfm av1_lowbd_fwd_txfm_c
++
++void av1_nn_fast_softmax_16_c(const float* input_nodes, float* output);
++#define av1_nn_fast_softmax_16 av1_nn_fast_softmax_16_c
++
++void av1_nn_predict_c(const float* input_nodes,
++                      const NN_CONFIG* const nn_config,
++                      int reduce_prec,
++                      float* const output);
++#define av1_nn_predict av1_nn_predict_c
++
++void av1_quantize_b_c(const tran_low_t* coeff_ptr,
++                      intptr_t n_coeffs,
++                      const int16_t* zbin_ptr,
++                      const int16_t* round_ptr,
++                      const int16_t* quant_ptr,
++                      const int16_t* quant_shift_ptr,
++                      tran_low_t* qcoeff_ptr,
++                      tran_low_t* dqcoeff_ptr,
++                      const int16_t* dequant_ptr,
++                      uint16_t* eob_ptr,
++                      const int16_t* scan,
++                      const int16_t* iscan,
++                      const qm_val_t* qm_ptr,
++                      const qm_val_t* iqm_ptr,
++                      int log_scale);
++#define av1_quantize_b av1_quantize_b_c
++
++void av1_quantize_fp_c(const tran_low_t* coeff_ptr,
++                       intptr_t n_coeffs,
++                       const int16_t* zbin_ptr,
++                       const int16_t* round_ptr,
++                       const int16_t* quant_ptr,
++                       const int16_t* quant_shift_ptr,
++                       tran_low_t* qcoeff_ptr,
++                       tran_low_t* dqcoeff_ptr,
++                       const int16_t* dequant_ptr,
++                       uint16_t* eob_ptr,
++                       const int16_t* scan,
++                       const int16_t* iscan);
++#define av1_quantize_fp av1_quantize_fp_c
++
++void av1_quantize_fp_32x32_c(const tran_low_t* coeff_ptr,
++                             intptr_t n_coeffs,
++                             const int16_t* zbin_ptr,
++                             const int16_t* round_ptr,
++                             const int16_t* quant_ptr,
++                             const int16_t* quant_shift_ptr,
++                             tran_low_t* qcoeff_ptr,
++                             tran_low_t* dqcoeff_ptr,
++                             const int16_t* dequant_ptr,
++                             uint16_t* eob_ptr,
++                             const int16_t* scan,
++                             const int16_t* iscan);
++#define av1_quantize_fp_32x32 av1_quantize_fp_32x32_c
++
++void av1_quantize_fp_64x64_c(const tran_low_t* coeff_ptr,
++                             intptr_t n_coeffs,
++                             const int16_t* zbin_ptr,
++                             const int16_t* round_ptr,
++                             const int16_t* quant_ptr,
++                             const int16_t* quant_shift_ptr,
++                             tran_low_t* qcoeff_ptr,
++                             tran_low_t* dqcoeff_ptr,
++                             const int16_t* dequant_ptr,
++                             uint16_t* eob_ptr,
++                             const int16_t* scan,
++                             const int16_t* iscan);
++#define av1_quantize_fp_64x64 av1_quantize_fp_64x64_c
++
++void av1_quantize_lp_c(const int16_t* coeff_ptr,
++                       intptr_t n_coeffs,
++                       const int16_t* round_ptr,
++                       const int16_t* quant_ptr,
++                       int16_t* qcoeff_ptr,
++                       int16_t* dqcoeff_ptr,
++                       const int16_t* dequant_ptr,
++                       uint16_t* eob_ptr,
++                       const int16_t* scan);
++#define av1_quantize_lp av1_quantize_lp_c
++
++void av1_resize_and_extend_frame_c(const YV12_BUFFER_CONFIG* src,
++                                   YV12_BUFFER_CONFIG* dst,
++                                   const InterpFilter filter,
++                                   const int phase,
++                                   const int num_planes);
++#define av1_resize_and_extend_frame av1_resize_and_extend_frame_c
++
 +void av1_round_shift_array_c(int32_t* arr, int size, int bit);
 +#define av1_round_shift_array av1_round_shift_array_c
 +
-+int av1_selfguided_restoration_c(const uint8_t* dgd8,
-+                                 int width,
-+                                 int height,
-+                                 int dgd_stride,
-+                                 int32_t* flt0,
-+                                 int32_t* flt1,
-+                                 int flt_stride,
-+                                 int sgr_params_idx,
-+                                 int bit_depth,
-+                                 int highbd);
-+#define av1_selfguided_restoration av1_selfguided_restoration_c
++void av1_txb_init_levels_c(const tran_low_t* const coeff,
++                           const int width,
++                           const int height,
++                           uint8_t* const levels);
++#define av1_txb_init_levels av1_txb_init_levels_c
 +
 +void av1_upsample_intra_edge_c(uint8_t* p, int sz);
 +#define av1_upsample_intra_edge av1_upsample_intra_edge_c
@@ -4303,25 +4858,23 @@ index 0000000000..350fb916c1
 +void av1_upsample_intra_edge_high_c(uint16_t* p, int sz, int bd);
 +#define av1_upsample_intra_edge_high av1_upsample_intra_edge_high_c
 +
-+void av1_warp_affine_c(const int32_t* mat,
-+                       const uint8_t* ref,
-+                       int width,
-+                       int height,
-+                       int stride,
-+                       uint8_t* pred,
-+                       int p_col,
-+                       int p_row,
-+                       int p_width,
-+                       int p_height,
-+                       int p_stride,
-+                       int subsampling_x,
-+                       int subsampling_y,
-+                       ConvolveParams* conv_params,
-+                       int16_t alpha,
-+                       int16_t beta,
-+                       int16_t gamma,
-+                       int16_t delta);
-+#define av1_warp_affine av1_warp_affine_c
++void av1_wedge_compute_delta_squares_c(int16_t* d,
++                                       const int16_t* a,
++                                       const int16_t* b,
++                                       int N);
++#define av1_wedge_compute_delta_squares av1_wedge_compute_delta_squares_c
++
++int8_t av1_wedge_sign_from_residuals_c(const int16_t* ds,
++                                       const uint8_t* m,
++                                       int N,
++                                       int64_t limit);
++#define av1_wedge_sign_from_residuals av1_wedge_sign_from_residuals_c
++
++uint64_t av1_wedge_sse_from_residuals_c(const int16_t* r1,
++                                        const int16_t* d,
++                                        const uint8_t* m,
++                                        int N);
++#define av1_wedge_sse_from_residuals av1_wedge_sse_from_residuals_c
 +
 +void av1_wiener_convolve_add_src_c(const uint8_t* src,
 +                                   ptrdiff_t src_stride,
@@ -4335,6 +4888,22 @@ index 0000000000..350fb916c1
 +                                   int h,
 +                                   const ConvolveParams* conv_params);
 +#define av1_wiener_convolve_add_src av1_wiener_convolve_add_src_c
++
++void cdef_copy_rect8_16bit_to_16bit_c(uint16_t* dst,
++                                      int dstride,
++                                      const uint16_t* src,
++                                      int sstride,
++                                      int v,
++                                      int h);
++#define cdef_copy_rect8_16bit_to_16bit cdef_copy_rect8_16bit_to_16bit_c
++
++void cdef_copy_rect8_8bit_to_16bit_c(uint16_t* dst,
++                                     int dstride,
++                                     const uint8_t* src,
++                                     int sstride,
++                                     int v,
++                                     int h);
++#define cdef_copy_rect8_8bit_to_16bit cdef_copy_rect8_8bit_to_16bit_c
 +
 +void cdef_filter_block_c(uint8_t* dst8,
 +                         uint16_t* dst16,
@@ -4355,61 +4924,27 @@ index 0000000000..350fb916c1
 +                    int coeff_shift);
 +#define cdef_find_dir cdef_find_dir_c
 +
-+cfl_subsample_hbd_fn cfl_get_luma_subsampling_420_hbd_c(TX_SIZE tx_size);
-+#define cfl_get_luma_subsampling_420_hbd cfl_get_luma_subsampling_420_hbd_c
-+
 +cfl_subsample_lbd_fn cfl_get_luma_subsampling_420_lbd_c(TX_SIZE tx_size);
 +#define cfl_get_luma_subsampling_420_lbd cfl_get_luma_subsampling_420_lbd_c
-+
-+cfl_subsample_hbd_fn cfl_get_luma_subsampling_422_hbd_c(TX_SIZE tx_size);
-+#define cfl_get_luma_subsampling_422_hbd cfl_get_luma_subsampling_422_hbd_c
 +
 +cfl_subsample_lbd_fn cfl_get_luma_subsampling_422_lbd_c(TX_SIZE tx_size);
 +#define cfl_get_luma_subsampling_422_lbd cfl_get_luma_subsampling_422_lbd_c
 +
-+cfl_subsample_hbd_fn cfl_get_luma_subsampling_444_hbd_c(TX_SIZE tx_size);
-+#define cfl_get_luma_subsampling_444_hbd cfl_get_luma_subsampling_444_hbd_c
-+
 +cfl_subsample_lbd_fn cfl_get_luma_subsampling_444_lbd_c(TX_SIZE tx_size);
 +#define cfl_get_luma_subsampling_444_lbd cfl_get_luma_subsampling_444_lbd_c
 +
-+void copy_rect8_16bit_to_16bit_c(uint16_t* dst,
-+                                 int dstride,
-+                                 const uint16_t* src,
-+                                 int sstride,
-+                                 int v,
-+                                 int h);
-+#define copy_rect8_16bit_to_16bit copy_rect8_16bit_to_16bit_c
++cfl_predict_lbd_fn cfl_get_predict_lbd_fn_c(TX_SIZE tx_size);
++#define cfl_get_predict_lbd_fn cfl_get_predict_lbd_fn_c
 +
-+void copy_rect8_8bit_to_16bit_c(uint16_t* dst,
-+                                int dstride,
-+                                const uint8_t* src,
-+                                int sstride,
-+                                int v,
-+                                int h);
-+#define copy_rect8_8bit_to_16bit copy_rect8_8bit_to_16bit_c
-+
-+cfl_predict_hbd_fn get_predict_hbd_fn_c(TX_SIZE tx_size);
-+#define get_predict_hbd_fn get_predict_hbd_fn_c
-+
-+cfl_predict_lbd_fn get_predict_lbd_fn_c(TX_SIZE tx_size);
-+#define get_predict_lbd_fn get_predict_lbd_fn_c
-+
-+cfl_subtract_average_fn get_subtract_average_fn_c(TX_SIZE tx_size);
-+cfl_subtract_average_fn get_subtract_average_fn_vsx(TX_SIZE tx_size);
-+#define get_subtract_average_fn get_subtract_average_fn_vsx
++cfl_subtract_average_fn cfl_get_subtract_average_fn_c(TX_SIZE tx_size);
++#define cfl_get_subtract_average_fn cfl_get_subtract_average_fn_c
 +
 +void av1_rtcd(void);
 +
 +#include "config/aom_config.h"
 +
 +#ifdef RTCD_C
-+#include "aom_ports/ppc.h"
-+static void setup_rtcd_internal(void) {
-+  int flags = ppc_simd_caps();
-+
-+  (void)flags;
-+}
++static void setup_rtcd_internal(void) {}
 +#endif
 +
 +#ifdef __cplusplus

--- a/lss/0001-WIP-ppc64-support.patch
+++ b/lss/0001-WIP-ppc64-support.patch
@@ -1,31 +1,17 @@
-From e3c840be85c5fd77fad362a81dd8126b4c9f85d9 Mon Sep 17 00:00:00 2001
-From: Shawn Anastasio <shawnanastasio@yahoo.com>
-Date: Mon, 13 Aug 2018 21:37:39 -0500
-Subject: [PATCH] WIP: ppc64 support
-
-Fixes:
-Don't check for mmap2 on ppc64
-(WORKAROUND) use system clone() on ppc64
-Properly define kernel_stat structs on ppc64
-Use individual socket syscalls on ppc64
----
- linux_syscall_support.h | 88 +++++++++++++++++++++++++++++++++++++----
- 1 file changed, 81 insertions(+), 7 deletions(-)
-
 diff --git a/linux_syscall_support.h b/linux_syscall_support.h
-index 129aa75..c8e5dae 100644
+index 8d4e4d2..e126a51 100644
 --- a/linux_syscall_support.h
 +++ b/linux_syscall_support.h
-@@ -372,7 +372,7 @@ struct kernel_stat64 {
+@@ -380,7 +380,7 @@ struct kernel_stat64 {
    unsigned           __pad2;
    unsigned long long st_blocks;
  };
 -#elif defined __PPC__
-+#elif defined __PPC__ && !defined(__powerpc64__)
++#elif defined(__PPC__) && !defined(__powerpc64__)
  struct kernel_stat64 {
    unsigned long long st_dev;
    unsigned long long st_ino;
-@@ -394,6 +394,28 @@ struct kernel_stat64 {
+@@ -402,6 +402,28 @@ struct kernel_stat64 {
    unsigned long      __unused4;
    unsigned long      __unused5;
  };
@@ -51,10 +37,10 @@ index 129aa75..c8e5dae 100644
 +  unsigned long int  __unused4;
 +  unsigned long int  __unused5;
 +};
- #else
+ #elif defined(__e2k__)
  struct kernel_stat64 {
    unsigned long long st_dev;
-@@ -468,7 +490,7 @@ struct kernel_stat {
+@@ -498,7 +520,7 @@ struct kernel_stat {
    uint64_t           st_ctime_nsec_;
    int64_t            __unused4[3];
  };
@@ -63,7 +49,7 @@ index 129aa75..c8e5dae 100644
  struct kernel_stat {
    unsigned           st_dev;
    unsigned long      st_ino;      // ino_t
-@@ -489,6 +511,29 @@ struct kernel_stat {
+@@ -519,6 +541,29 @@ struct kernel_stat {
    unsigned long      __unused4;
    unsigned long      __unused5;
  };
@@ -93,11 +79,10 @@ index 129aa75..c8e5dae 100644
  #elif (defined(__mips__) && _MIPS_SIM != _MIPS_SIM_ABI64)
  struct kernel_stat {
    unsigned           st_dev;
-@@ -1608,6 +1653,28 @@ struct kernel_statfs {
+@@ -1678,6 +1723,26 @@ struct kernel_statfs {
  #ifndef __NR_getcpu
  #define __NR_getcpu             302
  #endif
-+
 +/* Linux commit 86250b9d12caa1a3dee12a7cf638b7dd70eaadb6 (2010) adds
 + * direct socket system calls to PPC */
 +#ifndef __NR_socket
@@ -118,49 +103,10 @@ index 129aa75..c8e5dae 100644
 +#ifndef __NR_recvmsg
 +#define __NR_recvmsg            342
 +#endif
-+
  /* End of powerpc defininitions                                              */
  #elif defined(__s390__)
  #ifndef __NR_quotactl
-@@ -3146,6 +3213,11 @@ struct kernel_statfs {
-     /* TODO(csilvers): consider wrapping some args up in a struct, like we
-      * do for i386's _syscall6, so we can compile successfully on gcc 2.95
-      */
-+    #ifdef __powerpc64__
-+    /* TODO: implement clone() for ppc64.
-+     * until then, use system libc */
-+    #define sys_clone clone
-+    #else
-     LSS_INLINE int LSS_NAME(clone)(int (*fn)(void *), void *child_stack,
-                                    int flags, void *arg, int *parent_tidptr,
-                                    void *newtls, int *child_tidptr) {
-@@ -3216,6 +3288,7 @@ struct kernel_statfs {
-       }
-       LSS_RETURN(int, __ret, __err);
-     }
-+    #endif
-   #elif defined(__s390__)
-     #undef  LSS_REG
-     #define LSS_REG(r, a) register unsigned long __r##r __asm__("r"#r) = (unsigned long) a
-@@ -3905,7 +3978,7 @@ struct kernel_statfs {
-       LSS_REG(2, buf);
-       LSS_BODY(void*, mmap2, "0"(__r2));
-     }
--#else
-+#elif !defined(__powerpc64__) /* ppc64 doesn't have mmap2 */
-     #define __NR__mmap2 __NR_mmap2
-     LSS_INLINE _syscall6(void*, _mmap2,            void*, s,
-                          size_t,                   l, int,               p,
-@@ -4036,7 +4109,7 @@ struct kernel_statfs {
-   #if defined(__i386__) ||                                                    \
-       defined(__ARM_ARCH_3__) || defined(__ARM_EABI__) ||                     \
-      (defined(__mips__) && _MIPS_SIM == _MIPS_SIM_ABI32) ||                   \
--      defined(__PPC__) ||                                                     \
-+     (defined(__PPC__) && !defined(__powerpc64__)) ||                                                     \
-      (defined(__s390__) && !defined(__s390x__))
-     /* On these architectures, implement mmap() with mmap2(). */
-     LSS_INLINE void* LSS_NAME(mmap)(void *s, size_t l, int p, int f, int d,
-@@ -4070,7 +4143,7 @@ struct kernel_statfs {
+@@ -4395,7 +4460,7 @@ struct kernel_statfs {
      LSS_INLINE _syscall6(void*, mmap, void*, addr, size_t, length, int, prot,
                           int, flags, int, fd, int64_t, offset)
    #endif
@@ -169,25 +115,12 @@ index 129aa75..c8e5dae 100644
      #undef LSS_SC_LOADARGS_0
      #define LSS_SC_LOADARGS_0(dummy...)
      #undef LSS_SC_LOADARGS_1
-@@ -4159,7 +4232,8 @@ struct kernel_statfs {
+@@ -4484,7 +4549,7 @@ struct kernel_statfs {
        LSS_SC_BODY(4, int, 8, d, type, protocol, sv);
      }
    #endif
 -  #if defined(__ARM_EABI__) || defined (__aarch64__)
-+
 +  #if defined(__ARM_EABI__) || defined (__aarch64__) || defined(__powerpc64__)
      LSS_INLINE _syscall3(ssize_t, recvmsg, int, s, struct kernel_msghdr*, msg,
                           int, flags)
      LSS_INLINE _syscall3(ssize_t, sendmsg, int, s, const struct kernel_msghdr*,
-@@ -4444,7 +4518,7 @@ struct kernel_statfs {
- #endif
- 
- #if !defined(__NR_pipe)
--  LSS_INLINE int LSS_NAME(pipe)(int *pipefd) {
-+  LSS_INLINE pid_t LSS_NAME(pipe)(int *pipefd) {
-     return LSS_NAME(pipe2)(pipefd, 0);
-   }
- #endif
--- 
-2.17.1
-

--- a/patches.json
+++ b/patches.json
@@ -1,7 +1,5 @@
 {
     ".": [
-        "build_toolchain/Binutils-download.py-PPC.patch",
-
         "sandbox/0001-linux-seccomp-bpf-ppc64-glibc-workaround-in-SIGSYS-h.patch",
         "sandbox/0001-sandbox-Enable-seccomp_bpf-for-ppc64.patch",
         "sandbox/0001-sandbox-linux-bpf_dsl-Update-syscall-ranges-for-ppc6.patch",
@@ -14,6 +12,7 @@
         "sandbox/0004-sandbox-linux-system_headers-Update-linux-signal-hea.patch",
         "sandbox/0005-sandbox-linux-seccomp-bpf-Add-ppc64-syscall-stub.patch",
         "sandbox/0005-sandbox-linux-update-unit-test-for-ppc64.patch",
+        "sandbox/0006-sandbox-linux-system_headers-Update-linux-stat.patch",
         "sandbox/Sandbox-linux-services-credentials.cc-PPC.patch",
 
         "third_party/0000-third_party-closure_compiler-Use-system-jvm.patch",
@@ -25,9 +24,14 @@
         "third_party/0001-third_party-lss-Don-t-look-for-mmap2-on-ppc64.patch",
         "third_party/0001-third_party-pffft-Include-altivec.h-on-ppc64-with-SI.patch",
         "third_party/0000-third_party-blink-skip-clang-format.patch",
+        "third_party/0001-third_party-ruy-build.patch",
+        "third_party/0001-third_party-swiftshader-build.patch",
+        "third_party/0001-third_party-tflite-build.patch",
 
         "webrtc/Modules-desktop_capture-differ_block.cc-PPC.patch",
         "webrtc/Rtc_base-system-arch.h-PPC.patch",
+
+        "breakpad/0001-ppc64-have-context-support.patch",
 
         "crashpad/0002-Include-cstddef-to-fix-build.patch",
 
@@ -55,6 +59,10 @@
 
     "third_party/pdfium" : [
         "pdfium/0001-pdfium-allocator-Use-64k-page-sizes-on-ppc64.patch"
+    ],
+
+    "third_party/lss": [
+        "lss/0001-WIP-ppc64-support.patch"
     ],
 
     "third_party/libdrm/src": [

--- a/sandbox/0001-sandbox-linux-Implement-partial-support-for-ppc64-sy.patch
+++ b/sandbox/0001-sandbox-linux-Implement-partial-support-for-ppc64-sy.patch
@@ -11,9 +11,9 @@ GNU/Linux environments, but may require expansion elsewhere.
  sandbox/linux/BUILD.gn                              |  2 ++
  sandbox/linux/system_headers/linux_syscalls.h       |  4 ++++
  sandbox/linux/system_headers/linux_ucontext.h       |  2 ++
- sandbox/linux/system_headers/ppc64_linux_syscalls.h | 12 ++++++++++++
+ sandbox/linux/system_headers/ppc64_linux_syscalls.h | 16 ++++++++++++++++
  sandbox/linux/system_headers/ppc64_linux_ucontext.h | 12 ++++++++++++
- 5 files changed, 32 insertions(+)
+ 5 files changed, 36 insertions(+)
  create mode 100644 sandbox/linux/system_headers/ppc64_linux_syscalls.h
  create mode 100644 sandbox/linux/system_headers/ppc64_linux_ucontext.h
 
@@ -62,7 +62,7 @@ new file mode 100644
 index 000000000000..ccacffe22ea3
 --- /dev/null
 +++ b/sandbox/linux/system_headers/ppc64_linux_syscalls.h
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,16 @@
 +// Copyright 2014 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -71,6 +71,10 @@ index 000000000000..ccacffe22ea3
 +#define SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_SYSCALLS_H_
 +
 +#include <asm/unistd.h>
++
++#ifndef __NR_stat64
++#define __NR_stat64             195
++#endif
 +
 +//TODO: is it necessary to redefine syscall numbers for PPC64?
 +

--- a/sandbox/0001-sandbox-linux-Update-syscall-helpers-lists-for-ppc64.patch
+++ b/sandbox/0001-sandbox-linux-Update-syscall-helpers-lists-for-ppc64.patch
@@ -1,22 +1,8 @@
-From da52663deec77f705d7d58b18484c3e28e563f10 Mon Sep 17 00:00:00 2001
-From: Shawn Anastasio <shawnanastasio@yahoo.com>
-Date: Tue, 18 Sep 2018 18:39:28 -0500
-Subject: [PATCH] sandbox/linux: Update syscall helpers/lists for ppc64
-
----
- .../seccomp-bpf-helpers/baseline_policy.cc    |   8 +-
- .../syscall_parameters_restrictions.cc        |   2 +-
- .../syscall_parameters_restrictions.h         |   2 +-
- .../linux/seccomp-bpf-helpers/syscall_sets.cc | 108 ++++++++++--------
- .../linux/seccomp-bpf-helpers/syscall_sets.h  |   6 +-
- sandbox/linux/services/syscall_wrappers.cc    |   2 +-
- 6 files changed, 73 insertions(+), 55 deletions(-)
-
 diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
-index 426ea0757e5c..9c2f3d26bfc7 100644
+index 049e921694ed..bab60203e323 100644
 --- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
 +++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
-@@ -87,7 +87,8 @@ bool IsBaselinePolicyWatched(int sysno) {
+@@ -91,7 +91,8 @@ bool IsBaselinePolicyWatched(int sysno) {
           SyscallSets::IsPrctl(sysno) ||
           SyscallSets::IsProcessGroupOrSession(sysno) ||
  #if defined(__i386__) || \
@@ -26,27 +12,41 @@ index 426ea0757e5c..9c2f3d26bfc7 100644
           SyscallSets::IsSocketCall(sysno) ||
  #endif
  #if defined(__arm__)
-@@ -190,7 +191,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+@@ -188,11 +189,13 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+     return RestrictCloneToThreadsAndEPERMFork();
    }
- 
+
++#if !defined(__powerpc64__)
+   // clone3 takes a pointer argument which we cannot examine, so return ENOSYS
+   // to force the libc to use clone. See https://crbug.com/1213452.
+   if (sysno == __NR_clone3) {
+     return Error(ENOSYS);
+   }
++#endif
+
+   if (sysno == __NR_fcntl)
+     return RestrictFcntlCommands();
+@@ -258,7 +261,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+   }
+
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
 -    defined(__aarch64__)
 +    defined(__aarch64__) || defined(__powerpc64__)
    if (sysno == __NR_mmap)
      return RestrictMmapFlags();
  #endif
-@@ -208,7 +209,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+@@ -279,7 +282,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
      return RestrictPrctl();
- 
+
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
 -    defined(__aarch64__)
 +    defined(__aarch64__) || defined(__powerpc64__)
    if (sysno == __NR_socketpair) {
      // Only allow AF_UNIX, PF_UNIX. Crash if anything else is seen.
      static_assert(AF_UNIX == PF_UNIX,
-@@ -248,7 +249,8 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+@@ -343,7 +346,8 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
    }
- 
+
  #if defined(__i386__) || \
 -    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
 +    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
@@ -55,35 +55,37 @@ index 426ea0757e5c..9c2f3d26bfc7 100644
      return RestrictSocketcallCommand();
  #endif
 diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
-index 102647c14f14..670483fa40ae 100644
+index a8f860fcf082..be43e6c76724 100644
 --- a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
 +++ b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
-@@ -35,7 +35,8 @@
+@@ -39,8 +39,9 @@
  #include <sys/ioctl.h>
  #include <sys/ptrace.h>
- #if defined(OS_LINUX) && !defined(OS_CHROMEOS) && !defined(__arm__) && \
--    !defined(__aarch64__) && !defined(PTRACE_GET_THREAD_AREA)
-+    !defined(__aarch64__) && !defined(PTRACE_GET_THREAD_AREA) && \
+ #if (defined(OS_LINUX) || BUILDFLAG(IS_CHROMEOS_LACROS)) && \
+-    !defined(__arm__) && !defined(__aarch64__) &&           \
+-    !defined(PTRACE_GET_THREAD_AREA)
++    !defined(__arm__) && !defined(__aarch64__) && \
++    !defined(PTRACE_GET_THREAD_AREA) && \
 +    !defined(__powerpc64__)
  // Also include asm/ptrace-abi.h since ptrace.h in older libc (for instance
  // the one in Ubuntu 16.04 LTS) is missing PTRACE_GET_THREAD_AREA.
  // asm/ptrace-abi.h doesn't exist on arm32 and PTRACE_GET_THREAD_AREA isn't
-@@ -44,6 +45,11 @@
+@@ -49,6 +50,11 @@
  #endif
  #endif  // !OS_NACL_NONSFI
- 
+
 +// On PPC64, TCGETS is defined in terms of struct termios, so we must include termios.h
-+#ifdef __powerpc64__
++#if defined( __powerpc64__)
 +#include <termios.h>
 +#endif
 +
  #if defined(OS_ANDROID)
- 
+
  #if !defined(F_DUPFD_CLOEXEC)
-@@ -106,6 +112,15 @@ inline bool IsArchitectureMips() {
+@@ -106,6 +112,14 @@ inline bool IsArchitectureMips() {
  #endif
  }
- 
+
 +inline bool IsArchitecturePPC64() {
 +#if defined(__powerpc64__)
 +  return true;
@@ -92,11 +94,10 @@ index 102647c14f14..670483fa40ae 100644
 +#endif
 +}
 +
-+
  // Ubuntu's version of glibc has a race condition in sem_post that can cause
  // it to call futex(2) with bogus op arguments. To workaround this, we need
  // to allow those futex(2) calls to fail with EINVAL, instead of crashing the
-@@ -236,9 +251,11 @@ ResultExpr RestrictFcntlCommands() {
+@@ -257,7 +271,8 @@ ResultExpr RestrictFcntlCommands() {
    // operator.
    // Glibc overrides the kernel's O_LARGEFILE value. Account for this.
    uint64_t kOLargeFileFlag = O_LARGEFILE;
@@ -104,62 +105,41 @@ index 102647c14f14..670483fa40ae 100644
 +  if (IsArchitectureX86_64() || IsArchitectureI386() || IsArchitectureMips() \
 +      || IsArchitecturePPC64())
      kOLargeFileFlag = 0100000;
- 
-+
+
    const Arg<int> cmd(1);
-   const Arg<long> long_arg(2);
- 
-@@ -252,14 +269,23 @@ ResultExpr RestrictFcntlCommands() {
-               F_SETLKW,
-               F_GETLK,
-               F_DUPFD,
--              F_DUPFD_CLOEXEC),
--             Allow())
-+              F_DUPFD_CLOEXEC
-+#if defined(__powerpc64__)
-+// On PPC64, F_SETLK, F_GETLK, F_SETLKW are defined as the 64-bit variants
-+// but glibc will sometimes still use the 32-bit versions. Allow both.
-+              ,
-+              5, /* F_GETLK (32) */
-+              6, /* F_SETLK (32) */
-+              7  /* F_SETLKW (32) */
-+#endif
-+              ),
-+            Allow())
-       .Case(F_SETFL,
-             If((long_arg & ~kAllowedMask) == 0, Allow()).Else(CrashSIGSYS()))
-       .Default(CrashSIGSYS());
+@@ -286,7 +301,7 @@ ResultExpr RestrictFcntlCommands() {
+   // clang-format on
  }
- 
+
 -#if defined(__i386__) || defined(__mips__)
 +#if defined(__i386__) || defined(__mips__) || defined(__powerpc64__)
  ResultExpr RestrictSocketcallCommand() {
    // Unfortunately, we are unable to restrict the first parameter to
    // socketpair(2). Whilst initially sounding bad, it's noteworthy that very
-@@ -395,7 +421,7 @@ ResultExpr RestrictPrlimit(pid_t target_pid) {
- ResultExpr RestrictPtrace() {
-   const Arg<int> request(0);
-   return Switch(request).CASES((
+@@ -443,7 +458,7 @@ ResultExpr RestrictPtrace() {
+ #endif
+   return Switch(request)
+       .CASES((
 -#if !defined(__aarch64__)
 +#if !defined(__aarch64__) && !defined(__powerpc64__)
-         PTRACE_GETREGS,
-         PTRACE_GETFPREGS,
-         PTRACE_GET_THREAD_AREA,
+                  PTRACE_GETREGS, PTRACE_GETFPREGS, PTRACE_GET_THREAD_AREA,
+                  PTRACE_GETREGSET,
+ #endif
 diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h
-index 71c56093d92b..f8b9c0c6bf52 100644
+index 348970b39e76..94fc7f7ccd5d 100644
 --- a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h
 +++ b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h
-@@ -48,7 +48,7 @@ SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictMprotectFlags();
+@@ -49,7 +49,7 @@ SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictMprotectFlags();
  // O_NONBLOCK | O_SYNC | O_LARGEFILE | O_CLOEXEC | O_NOATIME.
  SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictFcntlCommands();
- 
+
 -#if defined(__i386__) || defined(__mips__)
 +#if defined(__i386__) || defined(__mips__) || defined(__powerpc64__)
  // Restrict socketcall(2) to only allow socketpair(2), send(2), recv(2),
  // sendto(2), recvfrom(2), shutdown(2), sendmsg(2) and recvmsg(2).
  SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictSocketcallCommand();
 diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
-index 7dbcc87522..af9d4aeb97 100644
+index 8227dc185464..07460d9930b2 100644
 --- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
 +++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
 @@ -29,7 +29,8 @@ bool SyscallSets::IsAllowedGettime(int sysno) {
@@ -172,9 +152,18 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_time:
  #endif
        return true;
-@@ -40,12 +41,14 @@ bool SyscallSets::IsAllowedGettime(int sysno) {
-     case __NR_clock_nanosleep:  // Could be allowed.
-     case __NR_clock_settime:    // Privileged.
+@@ -43,7 +44,7 @@ bool SyscallSets::IsAllowedGettime(int sysno) {
+
+       // time64 versions are available on 32-bit systems.
+ #if defined(__i386__) || defined(__arm__) || \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
+     case __NR_clock_gettime64:      // Parameters filtered by RestrictClockID().
+     case __NR_clock_settime64:      // Privileged.
+     case __NR_clock_adjtime64:      // Privileged.
+@@ -52,12 +53,14 @@ bool SyscallSets::IsAllowedGettime(int sysno) {
+     case __NR_clock_nanosleep_time64:  // Parameters filtered by RestrictClockID().
+ #endif
  #if defined(__i386__) || \
 -    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
 +    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
@@ -189,7 +178,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_stime:
  #endif
      default:
-@@ -111,7 +114,7 @@ bool SyscallSets::IsFileSystem(int sysno) {
+@@ -135,7 +138,7 @@ bool SyscallSets::IsFileSystem(int sysno) {
      case __NR_faccessat:  // EPERM not a valid errno.
      case __NR_fchmodat:
      case __NR_fchownat:  // Should be called chownat ?
@@ -198,7 +187,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_newfstatat:  // fstatat(). EPERM not a valid errno.
  #elif defined(__i386__) || defined(__arm__) || \
      (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
-@@ -130,7 +133,7 @@ bool SyscallSets::IsFileSystem(int sysno) {
+@@ -154,7 +157,7 @@ bool SyscallSets::IsFileSystem(int sysno) {
      case __NR_memfd_create:
      case __NR_mkdirat:
      case __NR_mknodat:
@@ -207,7 +196,14 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_oldlstat:
      case __NR_oldstat:
  #endif
-@@ -144,7 +147,8 @@ bool SyscallSets::IsFileSystem(int sysno) {
+@@ -163,12 +166,14 @@ bool SyscallSets::IsFileSystem(int sysno) {
+     case __NR_renameat:
+     case __NR_renameat2:
+ #if defined(__i386__) || defined(__arm__) || \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
++    defined(__powerpc64__)
+     case __NR_stat64:
  #endif
      case __NR_statfs:  // EPERM not a valid errno.
  #if defined(__i386__) || defined(__arm__) || \
@@ -216,8 +212,8 @@ index 7dbcc87522..af9d4aeb97 100644
 +    defined(__powerpc64__)
      case __NR_statfs64:
  #endif
-     case __NR_symlinkat:
-@@ -154,7 +158,8 @@ bool SyscallSets::IsFileSystem(int sysno) {
+     case __NR_statx:  // EPERM not a valid errno.
+@@ -179,7 +184,8 @@ bool SyscallSets::IsFileSystem(int sysno) {
      case __NR_truncate64:
  #endif
      case __NR_unlinkat:
@@ -227,7 +223,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_utime:
  #endif
      case __NR_utimensat:  // New.
-@@ -173,7 +178,8 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
+@@ -204,7 +210,8 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
  #endif
        return true;
  // TODO(jln): these should be denied gracefully as well (moved below).
@@ -237,7 +233,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_fadvise64:  // EPERM not a valid errno.
  #endif
  #if defined(__i386__)
-@@ -186,11 +192,12 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
+@@ -217,11 +224,12 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
      case __NR_flock:      // EPERM not a valid errno.
      case __NR_fstatfs:    // Give information about the whole filesystem.
  #if defined(__i386__) || defined(__arm__) || \
@@ -252,7 +248,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_oldfstat:
  #endif
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
-@@ -198,6 +205,8 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
+@@ -229,6 +237,8 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
      case __NR_sync_file_range:  // EPERM not a valid errno.
  #elif defined(__arm__)
      case __NR_arm_sync_file_range:  // EPERM not a valid errno.
@@ -261,7 +257,7 @@ index 7dbcc87522..af9d4aeb97 100644
  #endif
      default:
        return false;
-@@ -223,7 +232,8 @@ bool SyscallSets::IsDeniedFileSystemAccessViaFd(int sysno) {
+@@ -249,7 +259,8 @@ bool SyscallSets::IsDeniedFileSystemAccessViaFd(int sysno) {
  #endif
      case __NR_getdents64:  // EPERM not a valid errno.
  #if defined(__i386__) || \
@@ -271,7 +267,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_readdir:
  #endif
        return true;
-@@ -264,7 +274,7 @@ bool SyscallSets::IsGetSimpleId(int sysno) {
+@@ -290,7 +301,7 @@ bool SyscallSets::IsGetSimpleId(int sysno) {
  bool SyscallSets::IsProcessPrivilegeChange(int sysno) {
    switch (sysno) {
      case __NR_capset:
@@ -280,17 +276,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_ioperm:  // Intel privilege.
      case __NR_iopl:    // Intel privilege.
  #endif
-@@ -315,7 +325,8 @@ bool SyscallSets::IsAllowedSignalHandling(int sysno) {
-     case __NR_rt_sigreturn:
-     case __NR_rt_sigtimedwait:
- #if defined(__i386__) || defined(__arm__) || \
--    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
-+    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
-+    defined(__powerpc64__)
-     case __NR_sigaction:
-     case __NR_sigprocmask:
-     case __NR_sigreturn:
-@@ -331,7 +342,8 @@ bool SyscallSets::IsAllowedSignalHandling(int sysno) {
+@@ -358,7 +369,8 @@ bool SyscallSets::IsAllowedSignalHandling(int sysno) {
  #endif
      case __NR_signalfd4:
  #if defined(__i386__) || defined(__arm__) || \
@@ -300,7 +286,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_sigpending:
      case __NR_sigsuspend:
  #endif
-@@ -355,7 +367,7 @@ bool SyscallSets::IsAllowedOperationOnFd(int sysno) {
+@@ -382,7 +394,7 @@ bool SyscallSets::IsAllowedOperationOnFd(int sysno) {
  #endif
      case __NR_dup3:
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -309,7 +295,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_shutdown:
  #endif
        return true;
-@@ -388,7 +400,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+@@ -415,7 +427,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
      case __NR_exit_group:
      case __NR_wait4:
      case __NR_waitid:
@@ -318,7 +304,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_waitpid:
  #endif
        return true;
-@@ -405,7 +417,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+@@ -432,7 +444,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
  #endif
      case __NR_set_tid_address:
      case __NR_unshare:
@@ -327,7 +313,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_vfork:
  #endif
      default:
-@@ -454,7 +466,7 @@ bool SyscallSets::IsAllowedGetOrModifySocket(int sysno) {
+@@ -485,7 +497,7 @@ bool SyscallSets::IsAllowedGetOrModifySocket(int sysno) {
        return true;
      default:
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -336,7 +322,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_socketpair:  // We will want to inspect its argument.
  #endif
        return false;
-@@ -464,7 +476,7 @@ bool SyscallSets::IsAllowedGetOrModifySocket(int sysno) {
+@@ -495,7 +507,7 @@ bool SyscallSets::IsAllowedGetOrModifySocket(int sysno) {
  bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
    switch (sysno) {
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -345,9 +331,9 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_accept:
      case __NR_accept4:
      case __NR_bind:
-@@ -479,7 +491,8 @@ bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
+@@ -510,7 +522,8 @@ bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
  }
- 
+
  #if defined(__i386__) || \
 -    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
 +    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
@@ -355,17 +341,17 @@ index 7dbcc87522..af9d4aeb97 100644
  // Big multiplexing system call for sockets.
  bool SyscallSets::IsSocketCall(int sysno) {
    switch (sysno) {
-@@ -493,7 +506,8 @@ bool SyscallSets::IsSocketCall(int sysno) {
+@@ -524,7 +537,8 @@ bool SyscallSets::IsSocketCall(int sysno) {
  }
  #endif
- 
+
 -#if defined(__x86_64__) || defined(__arm__) || defined(__mips__)
 +#if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
 +    defined(__powerpc64__)
  bool SyscallSets::IsNetworkSocketInformation(int sysno) {
    switch (sysno) {
      case __NR_getpeername:
-@@ -518,7 +532,7 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
+@@ -549,7 +563,7 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
      case __NR_mincore:
      case __NR_mlockall:
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -374,7 +360,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_mmap:
  #endif
  #if defined(__i386__) || defined(__arm__) || \
-@@ -548,7 +562,8 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
+@@ -579,7 +593,8 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
    switch (sysno) {
      case __NR_lseek:
  #if defined(__i386__) || defined(__arm__) || \
@@ -384,7 +370,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR__llseek:
  #endif
  #if !defined(__aarch64__)
-@@ -560,26 +575,28 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
+@@ -599,26 +614,29 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
      case __NR_readv:
      case __NR_pread64:
  #if defined(__arm__) || \
@@ -404,7 +390,8 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_select:
  #endif
 -#if defined(__i386__) || defined(__arm__) || defined(__mips__)
-+#if defined(__i386__) || defined(__arm__) || defined(__mips__) || defined(__powerpc64__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips__) || \
++    defined(__powerpc64__)
      case __NR__newselect:
  #endif
  #if defined(__arm__) || \
@@ -419,7 +406,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_sendmsg:  // Could specify destination.
      case __NR_sendto:   // Could specify destination.
  #endif
-@@ -636,7 +653,8 @@ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
+@@ -674,7 +692,8 @@ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
        return true;
      case __NR_getpriority:
  #if defined(__i386__) || defined(__arm__) || \
@@ -429,7 +416,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_nice:
  #endif
      case __NR_setpriority:
-@@ -648,7 +666,8 @@ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
+@@ -686,7 +705,8 @@ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
  bool SyscallSets::IsAdminOperation(int sysno) {
    switch (sysno) {
  #if defined(__i386__) || defined(__arm__) || \
@@ -439,8 +426,8 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_bdflush:
  #endif
      case __NR_kexec_load:
-@@ -664,7 +683,8 @@ bool SyscallSets::IsAdminOperation(int sysno) {
- 
+@@ -702,7 +722,8 @@ bool SyscallSets::IsAdminOperation(int sysno) {
+
  bool SyscallSets::IsKernelModule(int sysno) {
    switch (sysno) {
 -#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
@@ -449,7 +436,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_create_module:
      case __NR_get_kernel_syms:  // Should ENOSYS.
      case __NR_query_module:
-@@ -697,7 +717,8 @@ bool SyscallSets::IsFsControl(int sysno) {
+@@ -735,7 +756,8 @@ bool SyscallSets::IsFsControl(int sysno) {
      case __NR_swapoff:
      case __NR_swapon:
  #if defined(__i386__) || \
@@ -459,7 +446,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_umount:
  #endif
      case __NR_umount2:
-@@ -713,7 +734,7 @@ bool SyscallSets::IsNuma(int sysno) {
+@@ -751,7 +773,7 @@ bool SyscallSets::IsNuma(int sysno) {
      case __NR_getcpu:
      case __NR_mbind:
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -468,7 +455,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_migrate_pages:
  #endif
      case __NR_move_pages:
-@@ -742,14 +763,15 @@ bool SyscallSets::IsGlobalProcessEnvironment(int sysno) {
+@@ -786,14 +808,15 @@ bool SyscallSets::IsGlobalProcessEnvironment(int sysno) {
    switch (sysno) {
      case __NR_acct:  // Privileged.
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -487,7 +474,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_ulimit:
  #endif
      case __NR_getrusage:
-@@ -783,7 +805,7 @@ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
+@@ -827,7 +850,7 @@ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
  #endif
      case __NR_sysinfo:
      case __NR_uname:
@@ -496,19 +483,9 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_olduname:
      case __NR_oldolduname:
  #endif
-@@ -847,7 +869,8 @@ bool SyscallSets::IsSystemVSemaphores(int sysno) {
- 
- #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
-     defined(__aarch64__) ||                                         \
--    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
-+    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || \
-+    defined(__powerpc64__)
- // These give a lot of ambient authority and bypass the setuid sandbox.
- bool SyscallSets::IsSystemVSharedMemory(int sysno) {
-   switch (sysno) {
-@@ -878,7 +901,8 @@ bool SyscallSets::IsSystemVMessageQueue(int sysno) {
+@@ -926,7 +949,8 @@ bool SyscallSets::IsSystemVMessageQueue(int sysno) {
  #endif
- 
+
  #if defined(__i386__) || \
 -    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
 +    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
@@ -516,7 +493,7 @@ index 7dbcc87522..af9d4aeb97 100644
  // Big system V multiplexing system call.
  bool SyscallSets::IsSystemVIpc(int sysno) {
    switch (sysno) {
-@@ -898,7 +922,8 @@ bool SyscallSets::IsAnySystemV(int sysno) {
+@@ -946,7 +970,8 @@ bool SyscallSets::IsAnySystemV(int sysno) {
    return IsSystemVMessageQueue(sysno) || IsSystemVSemaphores(sysno) ||
           IsSystemVSharedMemory(sysno);
  #elif defined(__i386__) || \
@@ -526,7 +503,7 @@ index 7dbcc87522..af9d4aeb97 100644
    return IsSystemVIpc(sysno);
  #endif
  }
-@@ -951,7 +976,8 @@ bool SyscallSets::IsFaNotify(int sysno) {
+@@ -1003,7 +1028,8 @@ bool SyscallSets::IsFaNotify(int sysno) {
  bool SyscallSets::IsTimer(int sysno) {
    switch (sysno) {
      case __NR_getitimer:
@@ -536,7 +513,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_alarm:
  #endif
      case __NR_setitimer:
-@@ -1010,18 +1036,22 @@ bool SyscallSets::IsMisc(int sysno) {
+@@ -1085,18 +1111,22 @@ bool SyscallSets::IsMisc(int sysno) {
      case __NR_syncfs:
      case __NR_vhangup:
  // The system calls below are not implemented.
@@ -563,7 +540,7 @@ index 7dbcc87522..af9d4aeb97 100644
      case __NR_gtty:
      case __NR_idle:
      case __NR_lock:
-@@ -1029,20 +1059,22 @@ bool SyscallSets::IsMisc(int sysno) {
+@@ -1104,20 +1134,22 @@ bool SyscallSets::IsMisc(int sysno) {
      case __NR_prof:
      case __NR_profil:
  #endif
@@ -591,12 +568,12 @@ index 7dbcc87522..af9d4aeb97 100644
  #endif
        return true;
 diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
-index c31d5e9c13b3..7898be9e1863 100644
+index 4921eed8cf04..63959e0561c4 100644
 --- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
 +++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
 @@ -43,13 +43,14 @@ class SANDBOX_EXPORT SyscallSets {
    static bool IsDeniedGetOrModifySocket(int sysno);
- 
+
  #if defined(__i386__) || \
 -    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
 +    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
@@ -604,14 +581,14 @@ index c31d5e9c13b3..7898be9e1863 100644
    // Big multiplexing system call for sockets.
    static bool IsSocketCall(int sysno);
  #endif
- 
+
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
 -    defined(__aarch64__)
 +    defined(__aarch64__) || defined(__powerpc64__)
    static bool IsNetworkSocketInformation(int sysno);
  #endif
- 
-@@ -77,7 +78,8 @@ class SANDBOX_EXPORT SyscallSets {
+
+@@ -78,7 +79,8 @@ class SANDBOX_EXPORT SyscallSets {
  #endif
  #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
      defined(__aarch64__) ||                                         \
@@ -621,9 +598,9 @@ index c31d5e9c13b3..7898be9e1863 100644
    // These give a lot of ambient authority and bypass the setuid sandbox.
    static bool IsSystemVSharedMemory(int sysno);
  #endif
-@@ -88,7 +90,8 @@ class SANDBOX_EXPORT SyscallSets {
+@@ -89,7 +91,8 @@ class SANDBOX_EXPORT SyscallSets {
  #endif
- 
+
  #if defined(__i386__) || \
 -    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
 +    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS)) || \
@@ -632,10 +609,10 @@ index c31d5e9c13b3..7898be9e1863 100644
    static bool IsSystemVIpc(int sysno);
  #endif
 diff --git a/sandbox/linux/services/syscall_wrappers.cc b/sandbox/linux/services/syscall_wrappers.cc
-index fcfd2aa129..f6eb32fb76 100644
+index 3bec18a14e91..481093339634 100644
 --- a/sandbox/linux/services/syscall_wrappers.cc
 +++ b/sandbox/linux/services/syscall_wrappers.cc
-@@ -58,7 +58,7 @@ long sys_clone(unsigned long flags,
+@@ -61,7 +61,7 @@ long sys_clone(unsigned long flags,
  #if defined(ARCH_CPU_X86_64)
    return syscall(__NR_clone, flags, child_stack, ptid, ctid, tls);
  #elif defined(ARCH_CPU_X86) || defined(ARCH_CPU_ARM_FAMILY) || \
@@ -644,7 +621,3 @@ index fcfd2aa129..f6eb32fb76 100644
    // CONFIG_CLONE_BACKWARDS defined.
    return syscall(__NR_clone, flags, child_stack, ptid, tls, ctid);
  #endif
-
--- 
-2.17.1
-

--- a/sandbox/0001-services-service_manager-sandbox-linux-Fix-TCGETS-de.patch
+++ b/sandbox/0001-services-service_manager-sandbox-linux-Fix-TCGETS-de.patch
@@ -8,22 +8,22 @@ Subject: [PATCH] services/service_manager/sandbox/linux: Fix TCGETS
  .../sandbox/linux/bpf_renderer_policy_linux.cc               | 5 +++++
  1 file changed, 5 insertions(+)
 
-diff --git a/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc b/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
-index bbeb3152da5d..156cd0d24650 100644
---- a/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
-+++ b/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
-@@ -15,6 +15,11 @@
- #include "sandbox/linux/system_headers/linux_syscalls.h"
- #include "services/service_manager/sandbox/linux/sandbox_linux.h"
- 
+diff --git a/sandbox/policy/linux/bpf_renderer_policy_linux.cc b/sandbox/policy/linux/bpf_renderer_policy_linux.cc
+index f789e92c37c1..8a374030fc05 100644
+--- a/sandbox/policy/linux/bpf_renderer_policy_linux.cc
++++ b/sandbox/policy/linux/bpf_renderer_policy_linux.cc
+@@ -19,6 +19,11 @@
+ // <linux/dma-buf.h> once kernel version 4.6 becomes widely used.
+ #include <linux/types.h>
+
 +// On PPC64, TCGETS is defined in terms of struct termios, so we must include termios.h
-+#ifdef __powerpc64__
++#if defined( __powerpc64__)
 +#include <termios.h>
 +#endif
 +
- // TODO(vignatti): replace the local definitions below with #include
- // <linux/dma-buf.h> once kernel version 4.6 becomes widely used.
- #include <linux/types.h>
+ struct local_dma_buf_sync {
+   __u64 flags;
+ };
 -- 
 2.17.1
 

--- a/sandbox/0006-sandbox-linux-system_headers-Update-linux-stat.patch
+++ b/sandbox/0006-sandbox-linux-system_headers-Update-linux-stat.patch
@@ -1,0 +1,34 @@
+diff --git a/sandbox/linux/system_headers/linux_stat.h b/sandbox/linux/system_headers/linux_stat.h
+index e697dd6777ef..20ef092d7484 100644
+--- a/sandbox/linux/system_headers/linux_stat.h
++++ b/sandbox/linux/system_headers/linux_stat.h
+@@ -155,6 +155,29 @@ struct kernel_stat {
+   unsigned int __unused4;
+   unsigned int __unused5;
+ };
++#elif defined(__powerpc64__)
++struct kernel_stat {
++  unsigned long int  st_dev;
++  unsigned long int  st_ino;
++  unsigned long int  st_nlink;
++  unsigned int       st_mode;
++  unsigned int       st_uid;
++  unsigned int       st_gid;
++  int                __pad2;
++  unsigned long int  st_rdev;
++  long int           st_size;
++  long int           st_blksize;
++  long int           st_blocks;
++  long int           st_atime_;
++  unsigned long int  st_atime_nsec_;
++  long int           st_mtime_;
++  unsigned long int  st_mtime_nsec_;
++  long int           st_ctime_;
++  unsigned long int  st_ctime_nsec_;
++  unsigned long int  __reserved4;
++  unsigned long int  __reserved5;
++  unsigned long int  __reserved6;
++};
+ #endif
+
+ #if !defined(AT_EMPTY_PATH)

--- a/third_party/0000-third_party-blink-skip-clang-format.patch
+++ b/third_party/0000-third_party-blink-skip-clang-format.patch
@@ -1,19 +1,21 @@
 diff --git a/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py b/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py
-index 7021f1a618..433f28fa61 100644
+index f7ef925f9c19..77d198642440 100644
 --- a/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py
 +++ b/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py
-@@ -150,6 +150,7 @@ def write_code_node_to_file(code_node, filepath):
- 
+@@ -174,6 +174,7 @@ def write_code_node_to_file(code_node, filepath):
+
      rendered_text = render_code_node(code_node)
- 
+
 +    """
      format_result = style_format.auto_format(rendered_text, filename=filepath)
      if not format_result.did_succeed:
          raise RuntimeError("Style-formatting failed: filename = {filename}\n"
-@@ -158,4 +159,5 @@ def write_code_node_to_file(code_node, filepath):
+@@ -181,6 +182,5 @@ def write_code_node_to_file(code_node, filepath):
+                            "{stderr}:".format(
                                 filename=format_result.filename,
                                 stderr=format_result.error_message))
- 
--    web_idl.file_io.write_to_file_if_changed(filepath, format_result.contents)
+-
+-    web_idl.file_io.write_to_file_if_changed(
+-        filepath, format_result.contents.encode('utf-8'))
 +    """
-+    web_idl.file_io.write_to_file_if_changed(filepath, rendered_text)
++    web_idl.file_io.write_to_file_if_changed(filepath, rendered_text.encode(encoding='UTF-8'))

--- a/third_party/0000-third_party-closure_compiler-Use-system-jvm.patch
+++ b/third_party/0000-third_party-closure_compiler-Use-system-jvm.patch
@@ -1,13 +1,13 @@
 diff --git a/third_party/closure_compiler/compiler.py b/third_party/closure_compiler/compiler.py
-index 4e9521c3bf..a0287c4ff0 100755
+index f09b7dd7a0ce..5308da5a64d2 100755
 --- a/third_party/closure_compiler/compiler.py
 +++ b/third_party/closure_compiler/compiler.py
-@@ -27,7 +27,7 @@ class Compiler(object):
+@@ -21,7 +21,7 @@ class Compiler(object):
    and produce minified output."""
- 
+
    _JAR_COMMAND = [
 -      _JAVA_PATH,
-+      "java",
++      "java ",
        "-jar",
        "-Xms1024m",
        "-client",

--- a/third_party/0001-DONTMERGE-third_party-node-Use-system-nodejs-binary.patch
+++ b/third_party/0001-DONTMERGE-third_party-node-Use-system-nodejs-binary.patch
@@ -11,13 +11,13 @@ and fall back to included ones if not.
  1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/third_party/node/node.py b/third_party/node/node.py
-index 8097e2c49acf..10e6a16eab12 100755
+index 573987ba0c30..f522928c7fc6 100755
 --- a/third_party/node/node.py
 +++ b/third_party/node/node.py
-@@ -10,11 +10,12 @@ import sys
- 
- 
- def GetBinaryPath():
+@@ -17,11 +17,12 @@ def GetBinaryPath():
+   if platform.system() == 'Darwin' and platform.machine() == 'arm64':
+       return os.path.join(os_path.join(os_path.dirname(__file__), 'mac',
+                           'node-darwin-arm64', 'bin', 'node'))
 -  return os_path.join(os_path.dirname(__file__), *{
 -    'Darwin': ('mac', 'node-darwin-x64', 'bin', 'node'),
 -    'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
@@ -29,9 +29,9 @@ index 8097e2c49acf..10e6a16eab12 100755
 +  #  'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
 +  #  'Windows': ('win', 'node.exe'),
 +  #}[platform.system()])
- 
- 
+
+
  def RunNode(cmd_parts, stdout=None):
--- 
+--
 2.17.1
 

--- a/third_party/0001-third_party-eigen3-tflite-update-latest-master.patch
+++ b/third_party/0001-third_party-eigen3-tflite-update-latest-master.patch
@@ -1,0 +1,31 @@
+diff --git a/DEPS b/DEPS
+index ccdd2c7287eb..95b054117f99 100644
+--- a/DEPS
++++ b/DEPS
+@@ -1016,7 +1006,7 @@ deps = {
+     Var('chromium_git') + '/chromium/dom-distiller/dist.git' + '@' + 'f339eb9463714c3d31657c8ee1bd53d1c7e5c555',
+
+   'src/third_party/eigen3/src':
+-    Var('chromium_git') + '/external/gitlab.com/libeigen/eigen.git' + '@' + '011e0db31d1bed8b7f73662be6d57d9f30fa457a',
++    Var('chromium_git') + '/external/gitlab.com/libeigen/eigen.git' + '@' + '8dcf3e38ba9913021ce6a831836a59217e21baf2',
+
+   'src/third_party/emoji-metadata/src': {
+     'url': Var('chromium_git') + '/external/github.com/googlefonts/emoji-metadata' + '@' + '069b14c94db6c1625a143d9f82e07a08a29909cf',
+@@ -1528,7 +1518,7 @@ deps = {
+   },
+
+   'src/third_party/ruy/src':
+-    Var('chromium_git') + '/external/github.com/google/ruy.git' + '@' + '34ea9f4993955fa1ff4eb58e504421806b7f2e8f',
++    Var('chromium_git') + '/external/github.com/google/ruy.git' + '@' + '9c56af3fce210a8a103eda19bd6f47c08a9e3d90',
+
+   'src/third_party/skia':
+     Var('skia_git') + '/skia.git' + '@' +  Var('skia_revision'),
+@@ -1562,7 +1552,7 @@ deps = {
+   },
+
+   'src/third_party/tflite/src':
+-    Var('chromium_git') + '/external/github.com/tensorflow/tensorflow.git' + '@' + 'fcc4b966f1265f466e82617020af93670141b009',
++    Var('chromium_git') + '/external/github.com/tensorflow/tensorflow.git' + '@' + 'a549323b446b3b0fed205df6ea5f28b050966a72',
+
+   'src/third_party/turbine': {
+       'packages': [

--- a/third_party/0001-third_party-libvpx-Properly-generate-gni-on-ppc64.patch
+++ b/third_party/0001-third_party-libvpx-Properly-generate-gni-on-ppc64.patch
@@ -22,18 +22,6 @@ index c1b718e..db3b003 100644
  
    configs -= [ "//build/config/compiler:chromium_code" ]
    configs += [ "//build/config/compiler:no_chromium_code" ]
-   
-@@ -401,7 +412,10 @@ static_library("libvp9rc") {
-     } else {
-       sources = libvpx_srcs_arm64
-     }
-+  } else if (current_cpu == "ppc64") {
-+    sources = libvpx_srcs_ppc64
-   }
-+
-   sources += [ "//third_party/libvpx/source/libvpx/vp9/ratectrl_rtc.cc" ]
-   sources += [ "//third_party/libvpx/source/libvpx/vp9/ratectrl_rtc.h" ]
-   
 diff --git a/third_party/libvpx/generate_gni.sh b/third_party/libvpx/generate_gni.sh
 index 2c94f6f685a3..c1758c6f193a 100755
 --- a/third_party/libvpx/generate_gni.sh

--- a/third_party/0001-third_party-lss-Don-t-look-for-mmap2-on-ppc64.patch
+++ b/third_party/0001-third_party-lss-Don-t-look-for-mmap2-on-ppc64.patch
@@ -1,6 +1,6 @@
 --- a/third_party/lss/linux_syscall_support.h
 +++ b/third_party/lss/linux_syscall_support.h
-@@ -3905,7 +3905,7 @@
+@@ -4250,7 +4250,7 @@ struct kernel_statfs {
        LSS_REG(2, buf);
        LSS_BODY(void*, mmap2, "0"(__r2));
      }
@@ -9,12 +9,12 @@
      #define __NR__mmap2 __NR_mmap2
      LSS_INLINE _syscall6(void*, _mmap2,            void*, s,
                           size_t,                   l, int,               p,
-@@ -4036,7 +4036,7 @@
+@@ -4361,7 +4361,7 @@ struct kernel_statfs {
    #if defined(__i386__) ||                                                    \
        defined(__ARM_ARCH_3__) || defined(__ARM_EABI__) ||                     \
       (defined(__mips__) && _MIPS_SIM == _MIPS_SIM_ABI32) ||                   \
 -      defined(__PPC__) ||                                                     \
-+     (defined(__PPC__) && !defined(__powerpc64__)) ||                                                     \
++     (defined(__PPC__) && !defined(__powerpc64__)) ||                      \
       (defined(__s390__) && !defined(__s390x__))
      /* On these architectures, implement mmap() with mmap2(). */
      LSS_INLINE void* LSS_NAME(mmap)(void *s, size_t l, int p, int f, int d,

--- a/third_party/0001-third_party-ruy-build.patch
+++ b/third_party/0001-third_party-ruy-build.patch
@@ -1,0 +1,106 @@
+diff --git a/third_party/ruy/BUILD.gn b/third_party/ruy/BUILD.gn
+index 53d29149711d..4d6e6632fc88 100644
+--- a/third_party/ruy/BUILD.gn
++++ b/third_party/ruy/BUILD.gn
+@@ -6,18 +6,24 @@ config("ruy_includes") {
+   include_dirs = [ "src" ]
+ }
+
++config("ruy_flags") {
++  if (target_cpu == "arm" || target_cpu == "arm64") {
++    cflags = [ "-Wno-inline-asm" ]
++  }
++}
++
+ source_set("ruy") {
+   sources = [
+     "src/ruy/allocator.cc",
+     "src/ruy/allocator.h",
+     "src/ruy/apply_multiplier.cc",
+     "src/ruy/apply_multiplier.h",
++    "src/ruy/asm_helpers.h",
+     "src/ruy/block_map.cc",
+     "src/ruy/block_map.h",
+     "src/ruy/blocking_counter.cc",
+     "src/ruy/blocking_counter.h",
+     "src/ruy/check_macros.h",
+-    "src/ruy/common.h",
+     "src/ruy/context.cc",
+     "src/ruy/context.h",
+     "src/ruy/context_get_ctx.cc",
+@@ -25,26 +31,25 @@ source_set("ruy") {
+     "src/ruy/cpu_cache_params.h",
+     "src/ruy/cpuinfo.cc",
+     "src/ruy/cpuinfo.h",
+-    "src/ruy/create_trmul_params.cc",
+     "src/ruy/create_trmul_params.h",
+     "src/ruy/ctx.cc",
+     "src/ruy/ctx.h",
+     "src/ruy/ctx_impl.h",
+-    "src/ruy/dispatch.h",
++    "src/ruy/denormal.cc",
++    "src/ruy/frontend.cc",
++    "src/ruy/frontend.h",
+     "src/ruy/have_built_path_for.h",
+-    "src/ruy/have_built_path_for_avx2.cc",
++    "src/ruy/have_built_path_for_avx.cc",
++    "src/ruy/have_built_path_for_avx2_fma.cc",
+     "src/ruy/have_built_path_for_avx512.cc",
+-    "src/ruy/have_built_path_for_avxvnni.cc",
+-    "src/ruy/have_built_path_for_sse42.cc",
+     "src/ruy/kernel.h",
+     "src/ruy/kernel_arm.h",
+     "src/ruy/kernel_arm32.cc",
+     "src/ruy/kernel_arm64.cc",
+-    "src/ruy/kernel_avx2.cc",
++    "src/ruy/kernel_avx.cc",
++    "src/ruy/kernel_avx2_fma.cc",
+     "src/ruy/kernel_avx512.cc",
+-    "src/ruy/kernel_avxvnni.cc",
+     "src/ruy/kernel_common.h",
+-    "src/ruy/kernel_sse42.cc",
+     "src/ruy/kernel_x86.h",
+     "src/ruy/mat.h",
+     "src/ruy/matrix.h",
+@@ -53,18 +58,20 @@ source_set("ruy") {
+     "src/ruy/pack.h",
+     "src/ruy/pack_arm.cc",
+     "src/ruy/pack_arm.h",
+-    "src/ruy/pack_avx2.cc",
++    "src/ruy/pack_avx.cc",
++    "src/ruy/pack_avx2_fma.cc",
+     "src/ruy/pack_avx512.cc",
+-    "src/ruy/pack_avxvnni.cc",
+     "src/ruy/pack_common.h",
+-    "src/ruy/pack_sse42.cc",
+     "src/ruy/pack_x86.h",
+     "src/ruy/path.h",
++    "src/ruy/performance_advisory.h",
+     "src/ruy/platform.h",
+     "src/ruy/pmu.cc",
+     "src/ruy/pmu.h",
+     "src/ruy/prepacked_cache.cc",
+     "src/ruy/prepacked_cache.h",
++    "src/ruy/prepare_packed_matrices.cc",
++    "src/ruy/prepare_packed_matrices.h",
+     "src/ruy/profiler/instrumentation.cc",
+     "src/ruy/profiler/instrumentation.h",
+     "src/ruy/profiler/profiler.cc",
+@@ -85,12 +92,14 @@ source_set("ruy") {
+     "src/ruy/trmul_params.h",
+     "src/ruy/tune.cc",
+     "src/ruy/tune.h",
++    "src/ruy/validate.h",
+     "src/ruy/wait.cc",
+     "src/ruy/wait.h",
+   ]
+-
+   configs -= [ "//build/config/compiler:chromium_code" ]
+-  configs += [ "//build/config/compiler:no_chromium_code" ]
+-
++  configs += [
++    ":ruy_flags",
++    "//build/config/compiler:no_chromium_code",
++  ]
+   public_configs = [ ":ruy_includes" ]
+ }

--- a/third_party/0001-third_party-swiftshader-build.patch
+++ b/third_party/0001-third_party-swiftshader-build.patch
@@ -1,0 +1,20 @@
+diff --git a/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn b/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
+index 25e84e541..b338bb2af 100644
+--- a/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
++++ b/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
+@@ -573,6 +573,7 @@ swiftshader_llvm_source_set("swiftshader_llvm_most") {
+     "llvm/lib/MC/ELFObjectWriter.cpp",
+     "llvm/lib/MC/MCAsmBackend.cpp",
+     "llvm/lib/MC/MCAsmInfo.cpp",
++    "llvm/lib/MC/MCAsmInfoXCOFF.cpp",
+     "llvm/lib/MC/MCAsmInfoCOFF.cpp",
+     "llvm/lib/MC/MCAsmInfoDarwin.cpp",
+     "llvm/lib/MC/MCAsmInfoELF.cpp",
+@@ -631,6 +632,7 @@ swiftshader_llvm_source_set("swiftshader_llvm_most") {
+     "llvm/lib/MC/MCWinCOFFStreamer.cpp",
+     "llvm/lib/MC/MCWinEH.cpp",
+     "llvm/lib/MC/MCXCOFFStreamer.cpp",
++    "llvm/lib/MC/MCXCOFFObjectTargetWriter.cpp",
+     "llvm/lib/MC/MachObjectWriter.cpp",
+     "llvm/lib/MC/StringTableBuilder.cpp",
+     "llvm/lib/MC/SubtargetFeature.cpp",

--- a/third_party/0001-third_party-tflite-build.patch
+++ b/third_party/0001-third_party-tflite-build.patch
@@ -1,0 +1,39 @@
+diff --git a/third_party/tflite/BUILD.gn b/third_party/tflite/BUILD.gn
+index df1f488a9f29..abf700d27dbb 100644
+--- a/third_party/tflite/BUILD.gn
++++ b/third_party/tflite/BUILD.gn
+@@ -77,6 +77,7 @@ source_set("tflite_public_headers") {
+     "src/tensorflow/lite/op_resolver.h",
+     "src/tensorflow/lite/optional_debug_tools.h",
+     "src/tensorflow/lite/schema/schema_generated.h",
++    "src/tensorflow/lite/schema/schema_utils.h",
+     "src/tensorflow/lite/stderr_reporter.h",
+     "src/tensorflow/lite/string_type.h",
+     "src/tensorflow/lite/string_util.h",
+@@ -405,6 +406,7 @@ static_library("tflite") {
+     "src/tensorflow/lite/graph_info.cc",
+     "src/tensorflow/lite/interpreter.cc",
+     "src/tensorflow/lite/interpreter_builder.cc",
++    "src/tensorflow/lite/interpreter_experimental.cc",
+     "src/tensorflow/lite/memory_planner.h",
+     "src/tensorflow/lite/minimal_logging.cc",
+     "src/tensorflow/lite/minimal_logging.h",
+@@ -420,6 +422,9 @@ static_library("tflite") {
+     "src/tensorflow/lite/profiling/memory_info.h",
+     "src/tensorflow/lite/profiling/time.cc",
+     "src/tensorflow/lite/profiling/time.h",
++    "src/tensorflow/lite/profiling/platform_profiler.cc",
++    "src/tensorflow/lite/profiling/platform_profiler.h",
++    "src/tensorflow/lite/schema/schema_utils.cc",
+     "src/tensorflow/lite/simple_memory_arena.cc",
+     "src/tensorflow/lite/simple_memory_arena.h",
+     "src/tensorflow/lite/stderr_reporter.cc",
+@@ -434,6 +439,8 @@ static_library("tflite") {
+     "src/tensorflow/lite/tools/tool_params.h",
+     "src/tensorflow/lite/tools/verifier.cc",
+     "src/tensorflow/lite/tools/verifier.h",
++    "src/tensorflow/lite/tools/verifier_internal.cc",
++    "src/tensorflow/lite/tools/verifier_internal.h",
+     "src/tensorflow/lite/type_to_tflitetype.h",
+     "src/tensorflow/lite/util.cc",
+     "src/tensorflow/lite/version.h",

--- a/webrtc/Modules-desktop_capture-differ_block.cc-PPC.patch
+++ b/webrtc/Modules-desktop_capture-differ_block.cc-PPC.patch
@@ -1,26 +1,14 @@
+diff --git a/third_party/webrtc/modules/desktop_capture/differ_block.cc b/third_party/webrtc/modules/desktop_capture/differ_block.cc
+index 4f0c5430c9..4b3b536e83 100644
 --- a/third_party/webrtc/modules/desktop_capture/differ_block.cc
 +++ b/third_party/webrtc/modules/desktop_capture/differ_block.cc
-@@ -30,11 +30,7 @@
+@@ -30,7 +30,8 @@ bool VectorDifference(const uint8_t* image1, const uint8_t* image2) {
    static bool (*diff_proc)(const uint8_t*, const uint8_t*) = nullptr;
- 
+
    if (!diff_proc) {
 -#if defined(WEBRTC_ARCH_ARM_FAMILY) || defined(WEBRTC_ARCH_MIPS_FAMILY)
--    // For ARM and MIPS processors, always use C version.
--    // TODO(hclam): Implement a NEON version.
--    diff_proc = &VectorDifference_C;
--#else
-+#if defined(WEBRTC_ARCH_X86_FAMILY)
-     bool have_sse2 = GetCPUInfo(kSSE2) != 0;
-     // For x86 processors, check if SSE2 is supported.
-     if (have_sse2 && kBlockSize == 32) {
-@@ -44,6 +40,10 @@
-     } else {
-       diff_proc = &VectorDifference_C;
-     }
-+#else
-+    // For other processors, always use C version.
-+    // TODO(hclam): Implement a NEON version.
-+    diff_proc = &VectorDifference_C;
- #endif
-   }
- 
++#if defined(WEBRTC_ARCH_ARM_FAMILY) || defined(WEBRTC_ARCH_MIPS_FAMILY) || \
++    defined(WEBRTC_ARCH_PPC_FAMILY)
+     // For ARM and MIPS processors, always use C version.
+     // TODO(hclam): Implement a NEON version.
+     diff_proc = &VectorDifference_C;

--- a/webrtc/Rtc_base-system-arch.h-PPC.patch
+++ b/webrtc/Rtc_base-system-arch.h-PPC.patch
@@ -1,21 +1,12 @@
+diff --git a/third_party/webrtc/rtc_base/system/arch.h b/third_party/webrtc/rtc_base/system/arch.h
+index be2367b85f..0e3f20d76e 100644
 --- a/third_party/webrtc/rtc_base/system/arch.h
 +++ b/third_party/webrtc/rtc_base/system/arch.h
-@@ -47,6 +47,18 @@
- #elif defined(__pnacl__)
- #define WEBRTC_ARCH_32_BITS
- #define WEBRTC_ARCH_LITTLE_ENDIAN
-+#elif defined(__PPC__)
-+#define WEBRTC_ARCH_PPC_FAMILY
-+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-+#define WEBRTC_ARCH_LITTLE_ENDIAN
-+#else
-+#define WEBRTC_ARCH_BIG_ENDIAN
-+#endif
-+#if defined(__LP64__)
-+#define WEBRTC_ARCH_64_BITS
-+#else
-+#define WEBRTC_ARCH_32_BITS
-+#endif
- #else
- #error Please add support for your architecture in typedefs.h
+@@ -50,6 +50,7 @@
+ #define WEBRTC_ARCH_BIG_ENDIAN
  #endif
+ #elif defined(__PPC__)
++#define WEBRTC_ARCH_PPC_FAMILY
+ #if defined(__PPC64__)
+ #define WEBRTC_ARCH_64_BITS
+ #else


### PR DESCRIPTION
Build latest chromium 95.0.4609.6 version on ppc64le and resolve the compilation error and update the existing patches.